### PR TITLE
GCI-773 Make Orders API depend on updated private SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<mockito-junit-jupiter-version>2.18.0</mockito-junit-jupiter-version>
 		<hamcrest-all-version>1.3</hamcrest-all-version>
 		<start-class>uk.gov.companieshouse.orders.api.OrdersApiApplication</start-class>
-		<private-api-sdk-java.version>2.0.20</private-api-sdk-java.version>
+		<private-api-sdk-java.version>2.0.26</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>1.0.2</api-sdk-manager-java-library.version>
 		<api-sdk-java.version>4.1.48</api-sdk-java.version>
 	</properties>


### PR DESCRIPTION
* Updated private API contains the recently added forename and surname fields.