### PR TITLE
GCI-780/GCI-781: Align checkout and order resources with updated spec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<mockito-junit-jupiter-version>2.18.0</mockito-junit-jupiter-version>
 		<hamcrest-all-version>1.3</hamcrest-all-version>
 		<start-class>uk.gov.companieshouse.orders.api.OrdersApiApplication</start-class>
-		<private-api-sdk-java.version>2.0.26</private-api-sdk-java.version>
+		<private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>1.0.2</api-sdk-manager-java-library.version>
 		<api-sdk-java.version>4.1.48</api-sdk-java.version>
 		<api-helper-java.version>1.4.1</api-helper-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<mockito-junit-jupiter-version>2.18.0</mockito-junit-jupiter-version>
 		<hamcrest-all-version>1.3</hamcrest-all-version>
 		<start-class>uk.gov.companieshouse.orders.api.OrdersApiApplication</start-class>
-		<private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+		<private-api-sdk-java.version>2.0.27</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>1.0.2</api-sdk-manager-java-library.version>
 		<api-sdk-java.version>4.1.48</api-sdk-java.version>
 		<api-helper-java.version>1.4.1</api-helper-java.version>

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/Item.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/Item.java
@@ -43,6 +43,10 @@ public class Item {
 
     private ItemStatus status;
 
+    private String postageCost;
+
+    private String totalItemCost;
+
     public String getId() {
         return id;
     }
@@ -177,5 +181,21 @@ public class Item {
 
     public void setStatus(ItemStatus status) {
         this.status = status;
+    }
+
+    public String getPostageCost() {
+        return postageCost;
+    }
+
+    public void setPostageCost(String postageCost) {
+        this.postageCost = postageCost;
+    }
+
+    public String getTotalItemCost() {
+        return totalItemCost;
+    }
+
+    public void setTotalItemCost(String totalItemCost) {
+        this.totalItemCost = totalItemCost;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/Item.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/Item.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.orders.api.model;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 public class Item {
@@ -22,7 +23,7 @@ public class Item {
 
     private Map<String, String> descriptionValues;
 
-    private ItemCosts itemCosts;
+    private List<ItemCosts> itemCosts;
 
     private CertificateItemOptions itemOptions;
 
@@ -98,11 +99,11 @@ public class Item {
         this.descriptionValues = descriptionValues;
     }
 
-    public ItemCosts getItemCosts() {
+    public List<ItemCosts> getItemCosts() {
         return itemCosts;
     }
 
-    public void setItemCosts(ItemCosts itemCosts) {
+    public void setItemCosts(List<ItemCosts> itemCosts) {
         this.itemCosts = itemCosts;
     }
 

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/ItemCosts.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/ItemCosts.java
@@ -4,20 +4,20 @@ public class ItemCosts {
 
     private String discountApplied;
 
-    private String individualItemCost;
+    private String itemCost;
 
-    private String postageCost;
+    private String calculatedCost;
 
-    private String totalCost;
+    private ProductType productType;
 
     public ItemCosts() {
     }
 
-    public ItemCosts(String discountApplied, String individualItemCost, String postageCost, String totalCost) {
+    public ItemCosts(String discountApplied, String itemCost, String calculatedCost, ProductType productType) {
         this.discountApplied = discountApplied;
-        this.individualItemCost = individualItemCost;
-        this.postageCost = postageCost;
-        this.totalCost = totalCost;
+        this.itemCost = itemCost;
+        this.calculatedCost = calculatedCost;
+        this.productType = productType;
     }
 
     public String getDiscountApplied() {
@@ -28,27 +28,27 @@ public class ItemCosts {
         this.discountApplied = discountApplied;
     }
 
-    public String getIndividualItemCost() {
-        return individualItemCost;
+    public String getItemCost() {
+        return itemCost;
     }
 
-    public void setIndividualItemCost(String individualItemCost) {
-        this.individualItemCost = individualItemCost;
+    public void setItemCost(String itemCost) {
+        this.itemCost = itemCost;
     }
 
-    public String getPostageCost() {
-        return postageCost;
+    public String getCalculatedCost() {
+        return calculatedCost;
     }
 
-    public void setPostageCost(String postageCost) {
-        this.postageCost = postageCost;
+    public void setCalculatedCost(String calculatedCost) {
+        this.calculatedCost = calculatedCost;
     }
 
-    public String getTotalCost() {
-        return totalCost;
+    public ProductType getProductType() {
+        return productType;
     }
 
-    public void setTotalCost(String totalCost) {
-        this.totalCost = totalCost;
+    public void setProductType(ProductType productType) {
+        this.productType = productType;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/ItemCosts.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/ItemCosts.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.orders.api.model;
 
+import java.util.Objects;
+
 public class ItemCosts {
 
     private String discountApplied;
@@ -50,5 +52,21 @@ public class ItemCosts {
 
     public void setProductType(ProductType productType) {
         this.productType = productType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ItemCosts)) return false;
+        ItemCosts itemCosts = (ItemCosts) o;
+        return Objects.equals(discountApplied, itemCosts.discountApplied) &&
+                Objects.equals(itemCost, itemCosts.itemCost) &&
+                Objects.equals(calculatedCost, itemCosts.calculatedCost) &&
+                productType == itemCosts.productType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(discountApplied, itemCost, calculatedCost, productType);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/ProductType.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/ProductType.java
@@ -1,0 +1,21 @@
+package uk.gov.companieshouse.orders.api.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import static uk.gov.companieshouse.orders.api.converter.EnumValueNameConverter.convertEnumValueNameToJson;
+
+/**
+ * Values of this represent the possible product types.
+ */
+public enum ProductType {
+    CERTIFICATE,
+    CERTIFICATE_SAME_DAY,
+    CERTIFICATE_ADDITIONAL_COPY,
+    SCAN_UPON_DEMAND,
+    CERTIFIED_COPY;
+
+    @JsonValue
+    public String getJsonName() {
+        return convertEnumValueNameToJson(this);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -16,17 +16,7 @@ import uk.gov.companieshouse.orders.api.dto.AddDeliveryDetailsRequestDTO;
 import uk.gov.companieshouse.orders.api.dto.AddToBasketRequestDTO;
 import uk.gov.companieshouse.orders.api.dto.BasketPaymentRequestDTO;
 import uk.gov.companieshouse.orders.api.dto.DeliveryDetailsDTO;
-import uk.gov.companieshouse.orders.api.model.ApiError;
-import uk.gov.companieshouse.orders.api.model.Basket;
-import uk.gov.companieshouse.orders.api.model.BasketData;
-import uk.gov.companieshouse.orders.api.model.BasketItem;
-import uk.gov.companieshouse.orders.api.model.Certificate;
-import uk.gov.companieshouse.orders.api.model.CertificateItemOptions;
-import uk.gov.companieshouse.orders.api.model.Checkout;
-import uk.gov.companieshouse.orders.api.model.DeliveryDetails;
-import uk.gov.companieshouse.orders.api.model.Item;
-import uk.gov.companieshouse.orders.api.model.Order;
-import uk.gov.companieshouse.orders.api.model.PaymentStatus;
+import uk.gov.companieshouse.orders.api.model.*;
 import uk.gov.companieshouse.orders.api.repository.BasketRepository;
 import uk.gov.companieshouse.orders.api.repository.CheckoutRepository;
 import uk.gov.companieshouse.orders.api.repository.OrderRepository;
@@ -35,10 +25,10 @@ import uk.gov.companieshouse.orders.api.service.CheckoutService;
 import uk.gov.companieshouse.orders.api.util.ResultCaptor;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Optional;
+import java.util.*;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -52,6 +42,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.companieshouse.orders.api.model.ProductType.CERTIFICATE_ADDITIONAL_COPY;
+import static uk.gov.companieshouse.orders.api.model.ProductType.CERTIFICATE_SAME_DAY;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_AUTHORISED_USER_HEADER_NAME;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_AUTHORISED_USER_VALUE;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_HEADER_NAME;
@@ -79,6 +71,13 @@ class BasketControllerIntegrationTest {
     private static final String SURNAME = "surname";
     private static final String CHECKOUT_ID = "1234";
     private static final String UNKNOWN_CHECKOUT_ID = "5555";
+
+    private static final List<ItemCosts> ITEM_COSTS =
+             asList(new ItemCosts( "0", "50", "50", CERTIFICATE_SAME_DAY),
+                    new ItemCosts("40", "50", "10", CERTIFICATE_ADDITIONAL_COPY),
+                    new ItemCosts("40", "50", "10", CERTIFICATE_ADDITIONAL_COPY));
+    private static final String POSTAGE_COST = "0";
+    private static final String TOTAL_ITEM_COST = "70";
 
     @Autowired
     private MockMvc mockMvc;
@@ -283,6 +282,50 @@ class BasketControllerIntegrationTest {
                 .andExpect(status().isBadRequest());
 
         assertEquals(0, checkoutRepository.count());
+    }
+
+    @Test
+    @DisplayName("Checkout basket successfully creates checkout with costs from Certificates API")
+    public void checkoutBasketCheckoutContainsCosts() throws Exception {
+        final Basket basket = new Basket();
+        basket.setId(ERIC_IDENTITY_VALUE);
+        BasketItem basketItem = new BasketItem();
+        basketItem.setItemUri(ITEM_URI);
+        basket.getData().getItems().add(basketItem);
+        basketRepository.save(basket);
+
+        final Certificate certificate = new Certificate();
+        certificate.setItemCosts(ITEM_COSTS);
+        certificate.setPostageCost(POSTAGE_COST);
+        certificate.setTotalItemCost(TOTAL_ITEM_COST);
+        when(apiClientService.getItem(ITEM_URI)).thenReturn(certificate);
+
+        final CheckoutData expectedResponseBody = new CheckoutData();
+        final Item item = new Item();
+        item.setItemCosts(ITEM_COSTS);
+        item.setPostageCost(POSTAGE_COST);
+        item.setTotalItemCost(TOTAL_ITEM_COST);
+        expectedResponseBody.setItems(singletonList(item));
+
+        final ResultCaptor<Checkout> resultCaptor = new ResultCaptor<>();
+        doAnswer(resultCaptor)
+                .when(checkoutService)
+                .createCheckout(any(Certificate.class), any(String.class), any(String.class));
+
+        mockMvc.perform(post("/basket/checkouts")
+                .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
+                .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
+                .header(ERIC_AUTHORISED_USER_HEADER_NAME, ERIC_AUTHORISED_USER_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(content().json(mapper.writeValueAsString(expectedResponseBody)));
+
+        final Optional<Checkout> retrievedCheckout = checkoutRepository.findById(resultCaptor.getResult().getId());
+        assertTrue(retrievedCheckout.isPresent());
+        final Item retrievedItem = retrievedCheckout.get().getData().getItems().get(0);
+        assertThat(retrievedItem.getItemCosts(), is(ITEM_COSTS));
+        assertThat(retrievedItem.getPostageCost(), is(POSTAGE_COST));
+        assertThat(retrievedItem.getTotalItemCost(), is(TOTAL_ITEM_COST));
+
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapperTest.java
@@ -52,6 +52,8 @@ public class ApiToCertificateMapperTest {
     private static final String SURNAME = "Smith";
 
     private static final String LINKS_SELF = "links/self";
+    private static final String POSTAGE_COST = "0";
+    private static final String TOTAL_ITEM_COST = "100";
 
     private static final CertificateItemOptionsApi ITEM_OPTIONS;
     private static final DirectorOrSecretaryDetailsApi DIRECTOR_OR_SECRETARY_DETAILS;
@@ -122,6 +124,8 @@ public class ApiToCertificateMapperTest {
         certificateApi.setPostalDelivery(POSTAL_DELIVERY);
         certificateApi.setItemOptions(ITEM_OPTIONS);
         certificateApi.setLinks(LINKS_API);
+        certificateApi.setPostageCost(POSTAGE_COST);
+        certificateApi.setTotalItemCost(TOTAL_ITEM_COST);
 
         final Certificate certificate = apiToCertificateMapper.apiToCertificate(certificateApi);
 
@@ -142,6 +146,8 @@ public class ApiToCertificateMapperTest {
 
         assertItemCosts(certificateApi.getItemCosts().get(0), certificate.getItemCosts().get(0));
         assertItemOptionsSame(certificateApi.getItemOptions(), certificate.getItemOptions());
+        assertThat(certificateApi.getPostageCost(), is(certificate.getPostageCost()));
+        assertThat(certificateApi.getTotalItemCost(), is(certificate.getTotalItemCost()));
     }
 
     private void assertItemCosts(final ItemCostsApi itemCostsApi, final ItemCosts itemCosts) {

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapperTest.java
@@ -12,10 +12,12 @@ import uk.gov.companieshouse.orders.api.model.*;
 
 import java.util.Map;
 
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static uk.gov.companieshouse.api.model.order.item.ProductTypeApi.CERTIFICATE;
 
 @ExtendWith(SpringExtension.class)
 @SpringJUnitConfig(ApiToCertificateMapperTest.Config.class)
@@ -67,9 +69,9 @@ public class ApiToCertificateMapperTest {
     static {
         ITEM_COSTS = new ItemCostsApi();
         ITEM_COSTS.setDiscountApplied("1");
-        ITEM_COSTS.setIndividualItemCost("2");
-        ITEM_COSTS.setPostageCost("3");
-        ITEM_COSTS.setTotalCost("4");
+        ITEM_COSTS.setItemCost("2");
+        ITEM_COSTS.setCalculatedCost("3");
+        ITEM_COSTS.setProductType(CERTIFICATE);
 
         DIRECTOR_OR_SECRETARY_DETAILS = new DirectorOrSecretaryDetailsApi();
         DIRECTOR_OR_SECRETARY_DETAILS.setIncludeAddress(INCLUDE_ADDRESS);
@@ -115,7 +117,7 @@ public class ApiToCertificateMapperTest {
         certificateApi.setDescription(DESCRIPTION);
         certificateApi.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
         certificateApi.setDescriptionValues(DESCRIPTION_VALUES);
-        certificateApi.setItemCosts(ITEM_COSTS);
+        certificateApi.setItemCosts(singletonList(ITEM_COSTS));
         certificateApi.setKind(KIND);
         certificateApi.setPostalDelivery(POSTAL_DELIVERY);
         certificateApi.setItemOptions(ITEM_OPTIONS);
@@ -138,15 +140,15 @@ public class ApiToCertificateMapperTest {
         assertThat(certificateApi.getLinks().getSelf(), is(certificate.getItemUri()));
         assertThat(certificateApi.getLinks().getSelf(), is(certificate.getLinks().getSelf()));
 
-        assertItemCosts(certificateApi.getItemCosts(), certificate.getItemCosts());
+        assertItemCosts(certificateApi.getItemCosts().get(0), certificate.getItemCosts().get(0));
         assertItemOptionsSame(certificateApi.getItemOptions(), certificate.getItemOptions());
     }
 
     private void assertItemCosts(final ItemCostsApi itemCostsApi, final ItemCosts itemCosts) {
         assertThat(itemCostsApi.getDiscountApplied(), is(itemCosts.getDiscountApplied()));
-        assertThat(itemCostsApi.getIndividualItemCost(), is(itemCosts.getIndividualItemCost()));
-        assertThat(itemCostsApi.getPostageCost(), is(itemCosts.getPostageCost()));
-        assertThat(itemCostsApi.getTotalCost(), is(itemCosts.getTotalCost()));
+        assertThat(itemCostsApi.getItemCost(), is(itemCosts.getItemCost()));
+        assertThat(itemCostsApi.getCalculatedCost(), is(itemCosts.getCalculatedCost()));
+        assertThat(itemCostsApi.getProductType().getJsonName(), is(itemCosts.getProductType().getJsonName()));
     }
 
     private void assertItemOptionsSame(final CertificateItemOptionsApi options1,

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapperTest.java
@@ -130,64 +130,64 @@ public class ApiToCertificateMapperTest {
         final Certificate certificate = apiToCertificateMapper.apiToCertificate(certificateApi);
 
         assertEquals(certificateApi.getId(), certificate.getId());
-        assertThat(certificateApi.getId(), is(certificate.getId()));
-        assertThat(certificateApi.getCompanyName(), is(certificate.getCompanyName()));
-        assertThat(certificateApi.getCompanyNumber(), is(certificate.getCompanyNumber()));
-        assertThat(certificateApi.getCustomerReference(), is(certificate.getCustomerReference()));
-        assertThat(certificateApi.getQuantity(), is(certificate.getQuantity()));
-        assertThat(certificateApi.getDescription(), is(certificate.getDescription()));
-        assertThat(certificateApi.getDescriptionIdentifier(), is(certificate.getDescriptionIdentifier()));
-        assertThat(certificateApi.getDescriptionValues(), is(certificate.getDescriptionValues()));
-        assertThat(certificateApi.getKind(), is(certificate.getKind()));
-        assertThat(certificateApi.isPostalDelivery(), is(certificate.isPostalDelivery()));
-        assertThat(certificateApi.getEtag(), is(certificate.getEtag()));
-        assertThat(certificateApi.getLinks().getSelf(), is(certificate.getItemUri()));
-        assertThat(certificateApi.getLinks().getSelf(), is(certificate.getLinks().getSelf()));
+        assertThat(certificate.getId(), is(certificateApi.getId()));
+        assertThat(certificate.getCompanyName(), is(certificateApi.getCompanyName()));
+        assertThat(certificate.getCompanyNumber(), is(certificateApi.getCompanyNumber()));
+        assertThat(certificate.getCustomerReference(), is(certificateApi.getCustomerReference()));
+        assertThat(certificate.getQuantity(), is(certificateApi.getQuantity()));
+        assertThat(certificate.getDescription(), is(certificateApi.getDescription()));
+        assertThat(certificate.getDescriptionIdentifier(), is(certificateApi.getDescriptionIdentifier()));
+        assertThat(certificate.getDescriptionValues(), is(certificateApi.getDescriptionValues()));
+        assertThat(certificate.getKind(), is(certificateApi.getKind()));
+        assertThat(certificate.isPostalDelivery(), is(certificateApi.isPostalDelivery()));
+        assertThat(certificate.getEtag(), is(certificateApi.getEtag()));
+        assertThat(certificate.getItemUri(), is(certificateApi.getLinks().getSelf()));
+        assertThat(certificate.getLinks().getSelf(), is(certificateApi.getLinks().getSelf()));
 
         assertItemCosts(certificateApi.getItemCosts().get(0), certificate.getItemCosts().get(0));
         assertItemOptionsSame(certificateApi.getItemOptions(), certificate.getItemOptions());
-        assertThat(certificateApi.getPostageCost(), is(certificate.getPostageCost()));
-        assertThat(certificateApi.getTotalItemCost(), is(certificate.getTotalItemCost()));
+        assertThat(certificate.getPostageCost(), is(certificateApi.getPostageCost()));
+        assertThat(certificate.getTotalItemCost(), is(certificateApi.getTotalItemCost()));
     }
 
     private void assertItemCosts(final ItemCostsApi itemCostsApi, final ItemCosts itemCosts) {
-        assertThat(itemCostsApi.getDiscountApplied(), is(itemCosts.getDiscountApplied()));
-        assertThat(itemCostsApi.getItemCost(), is(itemCosts.getItemCost()));
-        assertThat(itemCostsApi.getCalculatedCost(), is(itemCosts.getCalculatedCost()));
-        assertThat(itemCostsApi.getProductType().getJsonName(), is(itemCosts.getProductType().getJsonName()));
+        assertThat(itemCosts.getDiscountApplied(), is(itemCostsApi.getDiscountApplied()));
+        assertThat(itemCosts.getItemCost(), is(itemCostsApi.getItemCost()));
+        assertThat(itemCosts.getCalculatedCost(), is(itemCostsApi.getCalculatedCost()));
+        assertThat(itemCosts.getProductType().getJsonName(), is(itemCostsApi.getProductType().getJsonName()));
     }
 
-    private void assertItemOptionsSame(final CertificateItemOptionsApi options1,
-                                       final CertificateItemOptions options2) {
-        assertThat(options1.getCertificateType().getJsonName(), is(options2.getCertificateType().getJsonName()));
-        assertThat(options1.getCollectionLocation().getJsonName(), is(options2.getCollectionLocation().getJsonName()));
-        assertThat(options1.getContactNumber(), is(options2.getContactNumber()));
-        assertThat(options1.getDeliveryMethod().getJsonName(), is(options2.getDeliveryMethod().getJsonName()));
-        assertThat(options1.getDeliveryTimescale().getJsonName(), is(options2.getDeliveryTimescale().getJsonName()));
-        assertDetailsSame(options1.getDirectorDetails(), options2.getDirectorDetails());
-        assertThat(options1.getForename(), is(options2.getForename()));
-        assertThat(options1.getIncludeCompanyObjectsInformation(), is(options2.getIncludeCompanyObjectsInformation()));
-        assertThat(options1.getIncludeEmailCopy(), is(options2.getIncludeEmailCopy()));
-        assertThat(options1.getIncludeGoodStandingInformation(), is(options2.getIncludeGoodStandingInformation()));
-        assertAddressDetailsSame(options1.getRegisteredOfficeAddressDetails(), options2.getRegisteredOfficeAddressDetails());
-        assertDetailsSame(options1.getSecretaryDetails(), options2.getSecretaryDetails());
-        assertThat(options1.getSurname(), is(options2.getSurname()));
+    private void assertItemOptionsSame(final CertificateItemOptionsApi source,
+                                       final CertificateItemOptions target) {
+        assertThat(target.getCertificateType().getJsonName(), is(source.getCertificateType().getJsonName()));
+        assertThat(target.getCollectionLocation().getJsonName(), is(source.getCollectionLocation().getJsonName()));
+        assertThat(target.getContactNumber(), is(source.getContactNumber()));
+        assertThat(target.getDeliveryMethod().getJsonName(), is(source.getDeliveryMethod().getJsonName()));
+        assertThat(target.getDeliveryTimescale().getJsonName(), is(source.getDeliveryTimescale().getJsonName()));
+        assertDetailsSame(source.getDirectorDetails(), target.getDirectorDetails());
+        assertThat(target.getForename(), is(source.getForename()));
+        assertThat(target.getIncludeCompanyObjectsInformation(), is(source.getIncludeCompanyObjectsInformation()));
+        assertThat(target.getIncludeEmailCopy(), is(source.getIncludeEmailCopy()));
+        assertThat(target.getIncludeGoodStandingInformation(), is(source.getIncludeGoodStandingInformation()));
+        assertAddressDetailsSame(source.getRegisteredOfficeAddressDetails(), target.getRegisteredOfficeAddressDetails());
+        assertDetailsSame(source.getSecretaryDetails(), target.getSecretaryDetails());
+        assertThat(target.getSurname(), is(source.getSurname()));
     }
 
-    private void assertDetailsSame(final DirectorOrSecretaryDetailsApi details1,
-                                   final DirectorOrSecretaryDetails details2) {
-        assertThat(details1.getIncludeAddress(), is(details2.getIncludeAddress()));
-        assertThat(details1.getIncludeAppointmentDate(), is(details2.getIncludeAppointmentDate()));
-        assertThat(details1.getIncludeBasicInformation(), is(details2.getIncludeBasicInformation()));
-        assertThat(details1.getIncludeCountryOfResidence(), is(details2.getIncludeCountryOfResidence()));
-        assertThat(details1.getIncludeDobType().getJsonName(), is(details2.getIncludeDobType().getJsonName()));
-        assertThat(details1.getIncludeNationality(), is(details2.getIncludeNationality()));
-        assertThat(details1.getIncludeOccupation(), is(details2.getIncludeOccupation()));
+    private void assertDetailsSame(final DirectorOrSecretaryDetailsApi source,
+                                   final DirectorOrSecretaryDetails target) {
+        assertThat(target.getIncludeAddress(), is(source.getIncludeAddress()));
+        assertThat(target.getIncludeAppointmentDate(), is(source.getIncludeAppointmentDate()));
+        assertThat(target.getIncludeBasicInformation(), is(source.getIncludeBasicInformation()));
+        assertThat(target.getIncludeCountryOfResidence(), is(source.getIncludeCountryOfResidence()));
+        assertThat(target.getIncludeDobType().getJsonName(), is(source.getIncludeDobType().getJsonName()));
+        assertThat(target.getIncludeNationality(), is(source.getIncludeNationality()));
+        assertThat(target.getIncludeOccupation(), is(source.getIncludeOccupation()));
     }
 
-    private void assertAddressDetailsSame(final RegisteredOfficeAddressDetailsApi details1,
-                                          final RegisteredOfficeAddressDetails details2) {
-        assertThat(details1.getIncludeAddressRecordsType().getJsonName(), is(details2.getIncludeAddressRecordsType().getJsonName()));
-        assertThat(details1.getIncludeDates(), is(details2.getIncludeDates()));
+    private void assertAddressDetailsSame(final RegisteredOfficeAddressDetailsApi source,
+                                          final RegisteredOfficeAddressDetails target) {
+        assertThat(target.getIncludeAddressRecordsType().getJsonName(), is(source.getIncludeAddressRecordsType().getJsonName()));
+        assertThat(target.getIncludeDates(), is(source.getIncludeDates()));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
@@ -40,6 +40,8 @@ public class CheckoutToOrderMapperTest {
     private static final String DESCRIPTION_IDENTIFIER = "Description Identifier";
     private static final Map<String, String> DESCRIPTION_VALUES = singletonMap("key1", "value1");
     private static final ItemCosts ITEM_COSTS = new ItemCosts("1", "2", "3", CERTIFICATE);
+    private static final String POSTAGE_COST = "0";
+    private static final String TOTAL_ITEM_COST = "100";
     private static final String KIND = "certificate";
     private static final boolean POSTAL_DELIVERY = true;
     private static final String CUSTOMER_REFERENCE = "Certificate ordered by NJ.";
@@ -150,6 +152,8 @@ public class CheckoutToOrderMapperTest {
         item.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
         item.setDescriptionValues(DESCRIPTION_VALUES);
         item.setItemCosts(singletonList(ITEM_COSTS));
+        item.setPostageCost(POSTAGE_COST);
+        item.setTotalItemCost(TOTAL_ITEM_COST);
         item.setKind(KIND);
         item.setPostalDelivery(POSTAL_DELIVERY);
         item.setItemOptions(ITEM_OPTIONS);

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
@@ -24,6 +24,7 @@ import static uk.gov.companieshouse.orders.api.model.DeliveryTimescale.STANDARD;
 import static uk.gov.companieshouse.orders.api.model.IncludeAddressRecordsType.CURRENT;
 import static uk.gov.companieshouse.orders.api.model.IncludeDobType.PARTIAL;
 import static uk.gov.companieshouse.orders.api.model.PaymentStatus.PAID;
+import static uk.gov.companieshouse.orders.api.model.ProductType.CERTIFICATE;
 
 /**
  * Unit tests the {@link CheckoutToOrderMapperTest} class.
@@ -38,7 +39,7 @@ public class CheckoutToOrderMapperTest {
     private static final String DESCRIPTION = "Certificate";
     private static final String DESCRIPTION_IDENTIFIER = "Description Identifier";
     private static final Map<String, String> DESCRIPTION_VALUES = singletonMap("key1", "value1");
-    private static final ItemCosts ITEM_COSTS = new ItemCosts("1", "2", "3", "4");
+    private static final ItemCosts ITEM_COSTS = new ItemCosts("1", "2", "3", CERTIFICATE);
     private static final String KIND = "certificate";
     private static final boolean POSTAL_DELIVERY = true;
     private static final String CUSTOMER_REFERENCE = "Certificate ordered by NJ.";
@@ -148,7 +149,7 @@ public class CheckoutToOrderMapperTest {
         item.setDescription(DESCRIPTION);
         item.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
         item.setDescriptionValues(DESCRIPTION_VALUES);
-        item.setItemCosts(ITEM_COSTS);
+        item.setItemCosts(singletonList(ITEM_COSTS));
         item.setKind(KIND);
         item.setPostalDelivery(POSTAL_DELIVERY);
         item.setItemOptions(ITEM_OPTIONS);


### PR DESCRIPTION
* Changes made to the Certificates API costs fields to support multiple product codes now reflected here in resources made available by the Orders API too.
* This excludes anything that may be required to reflect the same changes in basket resources. Basket resources will be dealt with later in task GCI-797.