### PR TITLE
GCI-427: Check payment with payments.api when patching order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<hamcrest-all-version>1.3</hamcrest-all-version>
 		<start-class>uk.gov.companieshouse.orders.api.OrdersApiApplication</start-class>
 		<private-api-sdk-java.version>2.0.27</private-api-sdk-java.version>
-		<api-sdk-manager-java-library.version>1.0.2</api-sdk-manager-java-library.version>
+		<api-sdk-manager-java-library.version>1.0.3</api-sdk-manager-java-library.version>
 		<api-sdk-java.version>4.1.48</api-sdk-java.version>
 		<api-helper-java.version>1.4.1</api-helper-java.version>
 		<api-security-java.version>0.2.9</api-security-java.version>

--- a/src/main/java/uk/gov/companieshouse/orders/api/client/Api.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/client/Api.java
@@ -1,14 +1,20 @@
 package uk.gov.companieshouse.orders.api.client;
 
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
+import java.io.IOException;
+
 @Component
-public class ApiClient {
+public class Api {
 
     public InternalApiClient getInternalApiClient() {
         return ApiSdkManager.getPrivateSDK();
     }
 
+    public ApiClient getPublicApiClient(String passthroughHeader) throws IOException {
+        return ApiSdkManager.getSDK(passthroughHeader);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -230,10 +230,10 @@ public class BasketController {
 
             // Check the amount paid in the payment session and the amount expected in the order are the same
             if (Double.parseDouble(paymentSession.getAmount()) != calculateTotalAmountToBePaid(checkout)) {
-                LOGGER.error("Total amount paid for with payment session " + basketPaymentRequestDTO.getPaymentReference() + ": " + paymentSession.getAmount()
-                        + " does not match amount expected for order " + id + ": " + checkoutData.getTotalOrderCost());
-                return ResponseEntity.status(BAD_REQUEST).body("Total amount paid for with payment session " + basketPaymentRequestDTO.getPaymentReference() + ": "
-                        + paymentSession.getAmount() + " does not match amount expected for order " + id + ": " + checkoutData.getTotalOrderCost());
+                String errorMessage = "Total amount paid for with payment session " + basketPaymentRequestDTO.getPaymentReference() + ": " + paymentSession.getAmount()
+                        + " does not match amount expected for order " + id + ": " + checkoutData.getTotalOrderCost();
+                LOGGER.error(errorMessage);
+                return ResponseEntity.status(BAD_REQUEST).body(errorMessage);
             }
 
             // Get the URI for the resource in the payments session
@@ -241,10 +241,10 @@ public class BasketController {
                     .substring(paymentSession.getLinks().get("resource").lastIndexOf("/basket/checkouts/"));
             // Check that the URI that has been requested to mark as paid, matches URI from the payments session
             if (!paymentsResourceUri.equals(request.getRequestURI())) {
-                LOGGER.error("The URI that is attempted to be closed " + request.getRequestURI()
-                        + " does not match the URI that the payment session is created for " + paymentsResourceUri);
-                return ResponseEntity.status(BAD_REQUEST).body("The URI that is attempted to be closed " + request.getRequestURI()
-                        + " does not match the URI that the payment session is created for " + paymentsResourceUri);
+                String errorMessage = "The URI that is attempted to be closed " + request.getRequestURI()
+                        + " does not match the URI that the payment session is created for " + paymentsResourceUri;
+                LOGGER.error(errorMessage);
+                return ResponseEntity.status(BAD_REQUEST).body(errorMessage);
             }
 
             trace("Payment confirmed as paid with payments API for payment session: " + basketPaymentRequestDTO.getPaymentReference()

--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -194,7 +194,7 @@ public class BasketController {
         if (basketPaymentRequestDTO.getStatus() == PaymentStatus.PAID) {
             processSuccessfulPayment(requestId, updatedCheckout);
         }
-        return ResponseEntity.ok("");
+        return ResponseEntity.status(NO_CONTENT).body(null);
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -296,7 +296,13 @@ public class BasketController {
         trace("Cleared basket: " + basket, requestId);
     }
 
+    /**
+     * Performs the calculation to work out the total to be paid for this checkout.
+     * @param checkout the checkout required to calculate the total to be paid.
+     * @return the total to be paid
+     */
     private Double calculateTotalAmountToBePaid(Checkout checkout) {
+        // total is type Double to compare with decimal value that is returned from payments.api 
         Double total = 0.00;
         for (Item item : checkout.getData().getItems()) {
             for (ItemCosts itemCosts : item.getItemCosts()) {

--- a/src/main/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapper.java
@@ -15,7 +15,6 @@ import java.util.List;
 @Mapper(componentModel = "spring")
 public interface CheckoutToPaymentDetailsMapper {
 
-    @Mapping(source = "data.paidAt", target = "paidAt")
     @Mapping(source = "data.reference", target = "paymentReference")
     @Mapping(source = "data.status", target = "status")
     @Mapping(source = "data.links.payment", target = "links.self")

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
@@ -1,23 +1,32 @@
 package uk.gov.companieshouse.orders.api.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriTemplate;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.handler.order.item.request.PrivateItemURIPattern;
 import uk.gov.companieshouse.api.handler.regex.URIValidator;
 import uk.gov.companieshouse.api.model.order.item.CertificateApi;
-import uk.gov.companieshouse.orders.api.client.ApiClient;
+import uk.gov.companieshouse.api.model.payment.PaymentApi;
+import uk.gov.companieshouse.orders.api.client.Api;
 import uk.gov.companieshouse.orders.api.exception.ServiceException;
 import uk.gov.companieshouse.orders.api.mapper.ApiToCertificateMapper;
 import uk.gov.companieshouse.orders.api.model.Item;
 import uk.gov.companieshouse.orders.api.model.ItemStatus;
+
+import java.io.IOException;
 
 @Service
 public class ApiClientService {
 
     private final ApiToCertificateMapper apiToCertificateMapper;
 
-    private final ApiClient apiClient;
+    private final Api apiClient;
 
-    public ApiClientService(ApiToCertificateMapper apiToCertificateMapper, ApiClient apiClient) {
+    private static final UriTemplate GET_PAYMENT_URI =
+            new UriTemplate("/payments/{paymentId}");
+
+    public ApiClientService(ApiToCertificateMapper apiToCertificateMapper, Api apiClient) {
         this.apiToCertificateMapper = apiToCertificateMapper;
         this.apiClient = apiClient;
     }
@@ -31,6 +40,18 @@ public class ApiClientService {
             return certificate;
         } else {
             throw new ServiceException("Unrecognised uri pattern for "+itemUri);
+        }
+    }
+
+    public PaymentApi getPaymentSummary(String passthroughHeader, String paymentId) throws IOException {
+
+        try {
+            String uri = GET_PAYMENT_URI.expand(paymentId).toString();
+            return apiClient.getPublicApiClient(passthroughHeader).payment().get(uri).execute().getData();
+        } catch (ApiErrorResponseException ex) {
+            throw new ServiceException("Error retrieving payments session for " + paymentId + ", Error response: " + ex.getStatusCode());
+        } catch (URIValidationException ex) {
+            throw new ServiceException("Invalid URI for payments session" + paymentId);
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -578,7 +578,7 @@ class BasketControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("Patch basket payment details success path for paid payments session")
+    @DisplayName("Patch payment-details endpoint success path for paid payments session")
     public void patchBasketPaymentDetailsSuccessPaid() throws Exception {
         final LocalDateTime start = timestamps.start();
 
@@ -624,7 +624,7 @@ class BasketControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("Patch basket payment details success path for failed payments session")
+    @DisplayName("Patch payment-details endpoint success path for failed payments session")
     public void patchBasketPaymentDetailsSuccessFailed() throws Exception {
         final LocalDateTime start = timestamps.start();
 
@@ -648,7 +648,7 @@ class BasketControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("Patch basket payment details success path for no-funds payments session")
+    @DisplayName("Patch payment-details endpoint success path for no-funds payments session")
     public void patchBasketPaymentDetailsSuccessNoFunds() throws Exception {
         final LocalDateTime start = timestamps.start();
 
@@ -672,7 +672,7 @@ class BasketControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("Patch basket payment details failure checkout id doesn't not exist")
+    @DisplayName("Patch payment-details endpoint fails if the checkout id does not exist")
     void getPaymentDetailsReturnsNotFound() throws Exception {
 
         mockMvc.perform(get("/basket/checkouts/doesnotexist/payment")
@@ -685,7 +685,7 @@ class BasketControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("Patch basket payment details failure doesn't return payment session")
+    @DisplayName("Patch payment-details endpoint fails if it doesn't return payment session")
     public void patchBasketPaymentDetailsFailureReturningPaymentSession() throws Exception {
         final LocalDateTime start = timestamps.start();
 
@@ -711,7 +711,7 @@ class BasketControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("Patch basket payment details failure returning payment session")
+    @DisplayName("Patch payment details endpoints fails if status on payments service is not paid")
     public void patchBasketPaymentDetailsFailureCheckingPaymentStatus() throws Exception {
         final LocalDateTime start = timestamps.start();
 
@@ -738,7 +738,7 @@ class BasketControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("Patch basket payment details failure checking payment total")
+    @DisplayName("Patch payment details endpoints fails if payment total on payments service is different")
     public void patchBasketPaymentDetailsFailureCheckingPaymentTotal() throws Exception {
         final LocalDateTime start = timestamps.start();
 
@@ -765,7 +765,7 @@ class BasketControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("Patch basket payment details failure checkout resource being updated is correct")
+    @DisplayName("Patch payment details endpoints fails if checkout resource is different to the one on payments service")
     public void patchBasketPaymentDetailsFailureCheckingResourceUpdated() throws Exception {
         final LocalDateTime start = timestamps.start();
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
@@ -6,25 +6,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import uk.gov.companieshouse.api.model.payment.PaymentApi;
 import uk.gov.companieshouse.orders.api.dto.BasketPaymentRequestDTO;
-import uk.gov.companieshouse.orders.api.mapper.BasketMapper;
-import uk.gov.companieshouse.orders.api.mapper.CheckoutToPaymentDetailsMapper;
-import uk.gov.companieshouse.orders.api.mapper.DeliveryDetailsMapper;
-import uk.gov.companieshouse.orders.api.model.Checkout;
-import uk.gov.companieshouse.orders.api.model.CheckoutData;
-import uk.gov.companieshouse.orders.api.model.PaymentStatus;
+import uk.gov.companieshouse.orders.api.model.*;
 import uk.gov.companieshouse.orders.api.service.ApiClientService;
 import uk.gov.companieshouse.orders.api.service.BasketService;
 import uk.gov.companieshouse.orders.api.service.CheckoutService;
 import uk.gov.companieshouse.orders.api.service.OrderService;
-import uk.gov.companieshouse.orders.api.validator.CheckoutBasketValidator;
-import uk.gov.companieshouse.orders.api.validator.DeliveryDetailsValidator;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.Optional;
+import java.util.*;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Partially unit tests the {@link BasketController} class.
@@ -36,19 +32,13 @@ class BasketControllerTest {
     private BasketController controllerUnderTest;
 
     @Mock
-    private BasketMapper basketMapper;
+    private CheckoutService checkoutService;
 
     @Mock
-    private DeliveryDetailsMapper deliveryDetailsMapper;
-
-    @Mock
-    private CheckoutToPaymentDetailsMapper checkoutToPaymentDetailsMapper;
+    private OrderService orderService;
 
     @Mock
     private BasketService basketService;
-
-    @Mock
-    private CheckoutService checkoutService;
 
     @Mock
     private Checkout checkout;
@@ -57,53 +47,41 @@ class BasketControllerTest {
     private CheckoutData checkoutData;
 
     @Mock
-    private CheckoutBasketValidator checkoutBasketValidator;
-
-    @Mock
-    private DeliveryDetailsValidator deliveryDetailsValidator;
-
-    @Mock
     private ApiClientService apiClientService;
-
-    @Mock
-    private OrderService orderService;
-
-    @Mock
-    private BasketPaymentRequestDTO paymentStatusUpdate;
 
     @Test
     @DisplayName("Patch payment details PAID status update is saved to checkout")
-    void patchPaymentDetailsPaidStatusUpdateIsSaved() {
+    void patchPaymentDetailsPaidStatusUpdateIsSaved() throws IOException {
         patchPaymentDetailsStatusUpdateIsSaved(PaymentStatus.PAID);
     }
 
     @Test
     @DisplayName("Patch payment details FAILED status update is saved to checkout")
-    void patchPaymentDetailsFailedStatusUpdateIsSaved() {
+    void patchPaymentDetailsFailedStatusUpdateIsSaved() throws IOException {
         patchPaymentDetailsStatusUpdateIsSaved(PaymentStatus.FAILED);
     }
 
     @Test
     @DisplayName("Patch payment details PENDING status update is saved to checkout")
-    void patchPaymentDetailsPendingStatusUpdateIsSaved() {
+    void patchPaymentDetailsPendingStatusUpdateIsSaved() throws IOException {
         patchPaymentDetailsStatusUpdateIsSaved(PaymentStatus.PENDING);
     }
 
     @Test
     @DisplayName("Patch payment details EXPIRED status update is saved to checkout")
-    void patchPaymentDetailsExpiredStatusUpdateIsSaved() {
+    void patchPaymentDetailsExpiredStatusUpdateIsSaved() throws IOException {
         patchPaymentDetailsStatusUpdateIsSaved(PaymentStatus.EXPIRED);
     }
 
     @Test
     @DisplayName("Patch payment details IN_PROGRESS status update is saved to checkout")
-    void patchPaymentDetailsInProgressStatusUpdateIsSaved() {
+    void patchPaymentDetailsInProgressStatusUpdateIsSaved() throws IOException {
         patchPaymentDetailsStatusUpdateIsSaved(PaymentStatus.IN_PROGRESS);
     }
 
     @Test
     @DisplayName("Patch payment details NO_FUNDS status update is saved to checkout")
-    void patchPaymentDetailsNoFundsStatusUpdateIsSaved() {
+    void patchPaymentDetailsNoFundsStatusUpdateIsSaved() throws IOException {
         patchPaymentDetailsStatusUpdateIsSaved(PaymentStatus.NO_FUNDS);
     }
 
@@ -112,29 +90,68 @@ class BasketControllerTest {
      * and made any further updates required to the checkout for that updated status.
      * @param paymentOutcome the payment status updated value
      */
-    private void patchPaymentDetailsStatusUpdateIsSaved(final PaymentStatus paymentOutcome) {
+    private void patchPaymentDetailsStatusUpdateIsSaved(final PaymentStatus paymentOutcome) throws IOException {
 
         // Given
+        final String checkout_id = "123456789";
+        final String payment_id = "987654321";
+        final String eric_header = "EricHeader";
         final LocalDateTime paidAt = LocalDateTime.now();
+
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(ApiSdkManager.getEricPassthroughTokenHeader(), eric_header);
+        request.setRequestURI("/basket/checkouts/" + checkout_id + "/payment");
+
         final BasketPaymentRequestDTO paymentStatusUpdate = new BasketPaymentRequestDTO();
         paymentStatusUpdate.setStatus(paymentOutcome);
         paymentStatusUpdate.setPaidAt(paidAt);
-        paymentStatusUpdate.setPaymentReference("Payment reference");
+        paymentStatusUpdate.setPaymentReference(payment_id);
 
-        when(checkoutService.getCheckoutById("checkoutId")).thenReturn(Optional.of(checkout));
+        final PaymentApi paymentSummary = new PaymentApi();
+        paymentSummary.setStatus("paid");
+        paymentSummary.setAmount("211.03");
+        paymentSummary.setLinks(new HashMap<String, String>() {{
+            put("resource", "/basket/checkouts/" + checkout_id + "/payment");
+        }});
+
+        when(checkoutService.getCheckoutById(checkout_id)).thenReturn(Optional.of(checkout));
         when(checkout.getData()).thenReturn(checkoutData);
+        if (paymentOutcome.equals(PaymentStatus.PAID)) {
+            mockCheckoutDataItems();
+            when(apiClientService.getPaymentSummary("EricHeader", payment_id)).thenReturn(paymentSummary);
+        }
 
         // When
-        controllerUnderTest.patchBasketPaymentDetails(paymentStatusUpdate, "checkoutId", "requestId");
+        controllerUnderTest.patchBasketPaymentDetails(paymentStatusUpdate, request, checkout_id, "requestId");
 
         // Then
-        verify(checkout).getData();
         verify(checkoutData).setStatus(paymentOutcome);
-        if (paymentOutcome == PaymentStatus.PAID) {
+        if (paymentOutcome.equals(PaymentStatus.PAID)) {
             verify(checkoutData).setPaidAt(paidAt);
-            verify(checkoutData).setPaymentReference("Payment reference");
+            verify(checkoutData).setPaymentReference(payment_id);
         }
         verify(checkoutService).saveCheckout(checkout);
+    }
+
+    private void mockCheckoutDataItems() {
+        ArrayList<Item> items = new ArrayList<>();
+
+        Item mockItem1 = new Item();
+        ItemCosts mockItemCosts1 = new ItemCosts();
+        mockItemCosts1.setCalculatedCost("40.43");
+        ItemCosts mockItemCosts2 = new ItemCosts();
+        mockItemCosts2.setCalculatedCost("30.60");
+        mockItem1.setItemCosts(Arrays.asList(mockItemCosts1, mockItemCosts2));
+
+        Item mockItem2 = new Item();
+        ItemCosts mockItemCosts3 = new ItemCosts();
+        mockItemCosts3.setCalculatedCost("140");
+        mockItem2.setItemCosts(Arrays.asList(mockItemCosts3));
+
+        items.add(mockItem1);
+        items.add(mockItem2);
+
+        when(checkoutData.getItems()).thenReturn(items);
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
@@ -1,21 +1,30 @@
 package uk.gov.companieshouse.orders.api.service;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.handler.order.item.PrivateItemResourceHandler;
 import uk.gov.companieshouse.api.handler.order.item.request.CertificateGet;
+import uk.gov.companieshouse.api.handler.payment.PaymentResourceHandler;
+import uk.gov.companieshouse.api.handler.payment.request.PaymentGet;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.api.model.order.item.CertificateApi;
-import uk.gov.companieshouse.orders.api.client.ApiClient;
+import uk.gov.companieshouse.api.model.payment.PaymentApi;
+import uk.gov.companieshouse.orders.api.client.Api;
 import uk.gov.companieshouse.orders.api.exception.ServiceException;
 import uk.gov.companieshouse.orders.api.mapper.ApiToCertificateMapper;
 import uk.gov.companieshouse.orders.api.model.Certificate;
 import uk.gov.companieshouse.orders.api.model.Item;
 import uk.gov.companieshouse.orders.api.model.ItemStatus;
+
+import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -23,9 +32,14 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ApiClientServiceTest {
+    private static final String PAYMENT_ID = "987654321";
+    private static final String AMOUNT = "500";
+    private static final String DESCRIPTION = "description";
     private static final String VALID_CERTIFICATE_URI = "/orderable/certificates/CHS00001";
+    private static final String VALID_PAYMENT_URI = "/payments/" + PAYMENT_ID;
     private static final String INVALID_CERTIFICATE_URI = "/test/test/CHS00001";
     private static final String COMPANY_NUMBER = "00006400";
+    private static final String PASS_THROUGH_HEADER = "passThroughHeader";
 
     @InjectMocks
     private ApiClientService serviceUnderTest;
@@ -37,10 +51,19 @@ public class ApiClientServiceTest {
     private InternalApiClient mockInternalApiClient;
 
     @Mock
-    private ApiClient apiClient;
+    private ApiClient mockApiClient;
+
+    @Mock
+    private Api api;
 
     @Mock
     private PrivateItemResourceHandler privateItemResourceHandler;
+
+    @Mock
+    private PaymentResourceHandler paymentResourceHandler;
+
+    @Mock
+    private PaymentGet paymentGet;
 
     @Mock
     private CertificateGet certificateGet;
@@ -50,7 +73,7 @@ public class ApiClientServiceTest {
 
     @Test
     public void shouldGetCertificateItemIfUriIsValid() throws Exception {
-        when(apiClient.getInternalApiClient()).thenReturn(mockInternalApiClient);
+        when(api.getInternalApiClient()).thenReturn(mockInternalApiClient);
         when(mockInternalApiClient.privateItemResourceHandler()).thenReturn(privateItemResourceHandler);
         when(privateItemResourceHandler.getCertificate(VALID_CERTIFICATE_URI)).thenReturn(certificateGet);
         when(certificateGet.execute()).thenReturn(certificateApiResponse);
@@ -72,5 +95,47 @@ public class ApiClientServiceTest {
             Item item = serviceUnderTest.getItem(INVALID_CERTIFICATE_URI);
         });
         assertEquals("Unrecognised uri pattern for "+INVALID_CERTIFICATE_URI, exception.getMessage());
+    }
+
+    @Test
+    public void getPaymentSessionSuccess() throws IOException, URIValidationException {
+
+        PaymentApi paymentSession = new PaymentApi();
+        paymentSession.setAmount("500");
+        paymentSession.setDescription("description");
+
+        when(api.getPublicApiClient(PASS_THROUGH_HEADER)).thenReturn(mockApiClient);
+        when(mockApiClient.payment()).thenReturn(paymentResourceHandler);
+        when(mockApiClient.payment().get(VALID_PAYMENT_URI)).thenReturn(paymentGet);
+        when(paymentGet.execute()).thenReturn(new ApiResponse<>(201, null, paymentSession));
+
+        PaymentApi returnedPaymentSession = serviceUnderTest.getPaymentSummary(PASS_THROUGH_HEADER, PAYMENT_ID);
+
+        assertEquals(AMOUNT, returnedPaymentSession.getAmount());
+        assertEquals(DESCRIPTION, returnedPaymentSession.getDescription());
+    }
+
+    @Test
+    @DisplayName("Get Payment Session - URI Validation Exception Thrown")
+    void getPaymentSessionUriValidationExceptionThrown() throws IOException, URIValidationException {
+
+        when(api.getPublicApiClient(PASS_THROUGH_HEADER)).thenReturn(mockApiClient);
+        when(mockApiClient.payment()).thenReturn(paymentResourceHandler);
+        when(mockApiClient.payment().get(VALID_PAYMENT_URI)).thenReturn(paymentGet);
+        when(paymentGet.execute()).thenThrow(URIValidationException.class);
+
+        assertThrows(ServiceException.class, () -> serviceUnderTest.getPaymentSummary(PASS_THROUGH_HEADER, PAYMENT_ID));
+    }
+
+    @Test
+    @DisplayName("Get Payment Session - API Error Response Exception Thrown")
+    void getPaymentSessionApiResponseExceptionThrown() throws IOException, URIValidationException {
+
+        when(api.getPublicApiClient(PASS_THROUGH_HEADER)).thenReturn(mockApiClient);
+        when(mockApiClient.payment()).thenReturn(paymentResourceHandler);
+        when(mockApiClient.payment().get(VALID_PAYMENT_URI)).thenReturn(paymentGet);
+        when(paymentGet.execute()).thenThrow(ApiErrorResponseException.class);
+
+        assertThrows(ServiceException.class, () -> serviceUnderTest.getPaymentSummary(PASS_THROUGH_HEADER, PAYMENT_ID));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/util/TestConstants.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/util/TestConstants.java
@@ -7,6 +7,7 @@ public class TestConstants {
     public static final String TOKEN_REQUEST_ID_VALUE = "f058ebd6-02f7-4d3f-942e-904344e8cde5";
     public static final String ERIC_IDENTITY_HEADER_NAME = "ERIC-Identity";
     public static final String ERIC_IDENTITY_VALUE = "Y2VkZWVlMzhlZWFjY2M4MzQ3MT";
+    public static final String ERIC_ACCESS_TOKEN = "ericAccessToken";
     public static final String WRONG_ERIC_IDENTITY_VALUE = "Y1V1Z1V1M1h1Z1F1Y1M1M1Q1M1";
     public static final String ERIC_IDENTITY_TYPE_HEADER_NAME = "ERIC-Identity-Type";
     public static final String ERIC_IDENTITY_OAUTH2_TYPE_VALUE = "oauth2";

--- a/src/test/java/uk/gov/companieshouse/orders/api/util/TimestampedEntityVerifier.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/util/TimestampedEntityVerifier.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.orders.api.util;
 import uk.gov.companieshouse.orders.api.model.TimestampedEntity;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
@@ -23,19 +24,19 @@ public class TimestampedEntityVerifier {
      */
     private LocalDateTime intervalEnd;
 
-    /** Use to record the start of the test, prior to the invocation of the method under test.
+    /** Use to record the start of the test, rounded down to the closest millisecond, prior to the invocation of the method under test.
      * @return the recorded start timestamp
      */
     public LocalDateTime start() {
-        intervalStart = LocalDateTime.now();
+        intervalStart = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         return intervalStart;
     }
 
-    /** Use to record the end of the test, after the invocation of the method under test.
+    /** Use to record the end of the test, rounded up to the closest millisecond, after the invocation of the method under test.
      * @return the recorded end timestamp
      */
     public LocalDateTime end() {
-        intervalEnd = LocalDateTime.now();
+        intervalEnd = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS).plusNanos(1000000);
         return intervalEnd;
     }
 


### PR DESCRIPTION
Implements callback to the payments api when the patch endpoint on the payment-details URL has been hit. 

This verifies the payment exists, is paid, is the same amount as the checkout, and has the correct url as a resource before marking the checkout as paid. 

If the incoming patch request does not have a "paid" status the checkout is instead changed the incoming status, and the basket is not cleared.

Resolves: GCI-427 

Related PR's for story: 
https://github.com/companieshouse/api-sdk-manager-java-library/pull/7
https://github.com/companieshouse/payments.api.ch.gov.uk/pull/124