### PR TITLE
Add id attribute and update test

### DIFF
--- a/src/main/java/uk/gov/companieshouse/orders/api/dto/BasketItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/dto/BasketItemDTO.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 
 public class BasketItemDTO extends ItemDTO {
+    @JsonProperty("id")
+    private String id;
 
     @JsonProperty("company_name")
     private String companyName;
@@ -57,6 +59,10 @@ public class BasketItemDTO extends ItemDTO {
 
     @JsonProperty("total_item_cost")
     private String totalItemCost;
+
+    public String getId() { return id; }
+
+    public void setId(String id) { this.id = id; }
 
     public String getCompanyName() {
         return companyName;

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/ItemMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/ItemMapperTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.*;
 @SpringJUnitConfig(ItemMapperTest.Config.class)
 public class ItemMapperTest {
 
+    private static final String ID = "ID00000001";
     private static final String COMPANY_NUMBER = "00006400";
     private static final String COMPANY_NAME = "Test Test Ltd";
     private static final String CUSTOMER_REFERENCE = "Testing Reference";
@@ -53,6 +54,7 @@ public class ItemMapperTest {
 
     private Item createCertificate(){
         Certificate certificate = new Certificate();
+        certificate.setId(ID);
         certificate.setCompanyNumber(COMPANY_NUMBER);
         certificate.setCompanyName(COMPANY_NAME);
         certificate.setCustomerReference(CUSTOMER_REFERENCE);
@@ -97,6 +99,7 @@ public class ItemMapperTest {
         BasketItemDTO basketItemDTO = itemMapperUnderTest.itemToBasketItemDTO(itemToConvert);
         List<ItemCosts> itemCosts = basketItemDTO.getItemCosts();
 
+        assertThat(ID, is(basketItemDTO.getId()));
         assertThat(COMPANY_NAME, is(basketItemDTO.getCompanyName()));
         assertThat(COMPANY_NUMBER, is(basketItemDTO.getCompanyNumber()));
         assertThat(CUSTOMER_REFERENCE, is(basketItemDTO.getCustomerReference()));


### PR DESCRIPTION
Adds the missing `id` property to `BasketItemDTO` so the `basketItem` resource contains the `id` property when 'Add item to basket' is requested.