### PR TITLE
Add validation to catch missing delivery details for postal delivery request

### DIFF
--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -34,7 +34,6 @@ import uk.gov.companieshouse.orders.api.model.CheckoutData;
 import uk.gov.companieshouse.orders.api.model.DeliveryDetails;
 import uk.gov.companieshouse.orders.api.model.Item;
 import uk.gov.companieshouse.orders.api.model.ItemCosts;
-import uk.gov.companieshouse.orders.api.model.Order;
 import uk.gov.companieshouse.orders.api.model.PaymentStatus;
 import uk.gov.companieshouse.orders.api.service.ApiClientService;
 import uk.gov.companieshouse.orders.api.service.BasketService;
@@ -48,7 +47,6 @@ import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -59,8 +57,8 @@ import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
-import static uk.gov.companieshouse.orders.api.logging.LoggingUtils.APPLICATION_NAMESPACE;
 import static uk.gov.companieshouse.orders.api.OrdersApiApplication.REQUEST_ID_HEADER_NAME;
+import static uk.gov.companieshouse.orders.api.logging.LoggingUtils.APPLICATION_NAMESPACE;
 
 @RestController
 public class BasketController {
@@ -308,6 +306,12 @@ public class BasketController {
                 logMap.put(LoggingUtils.ERROR_TYPE, ErrorType.BASKET_ITEM_INVALID.getValue());
                 LOGGER.errorRequest(request, "Validation error - basket item invalid", logMap);
                 return ResponseEntity.status(BAD_REQUEST).body(new ApiError(BAD_REQUEST, errors));
+            }
+            else if (errors.contains(ErrorType.DELIVERY_DETAILS_MISSING.getValue())){
+                logMap.put(LoggingUtils.STATUS, CONFLICT);
+                logMap.put(LoggingUtils.ERROR_TYPE, ErrorType.DELIVERY_DETAILS_MISSING.getValue());
+                LOGGER.errorRequest(request, "Validation error - delivery details missing", logMap);
+                return ResponseEntity.status(CONFLICT).body(new ApiError(CONFLICT, errors));
             }
         }
 

--- a/src/main/java/uk/gov/companieshouse/orders/api/exception/ErrorType.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/exception/ErrorType.java
@@ -2,7 +2,8 @@ package uk.gov.companieshouse.orders.api.exception;
 
 public enum ErrorType {
     BASKET_ITEMS_MISSING("Basket is empty"),
-    BASKET_ITEM_INVALID("Failed to retrieve item");
+    BASKET_ITEM_INVALID("Failed to retrieve item"),
+    DELIVERY_DETAILS_MISSING("Delivery details missing for postal delivery");
 
     private String value;
 

--- a/src/main/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidator.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidator.java
@@ -1,9 +1,5 @@
 package uk.gov.companieshouse.orders.api.validator;
 
-import static uk.gov.companieshouse.orders.api.logging.LoggingUtils.APPLICATION_NAMESPACE;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -13,13 +9,21 @@ import uk.gov.companieshouse.orders.api.model.Basket;
 import uk.gov.companieshouse.orders.api.model.Item;
 import uk.gov.companieshouse.orders.api.service.ApiClientService;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static uk.gov.companieshouse.orders.api.logging.LoggingUtils.APPLICATION_NAMESPACE;
+
 @Component
 public class CheckoutBasketValidator {
     private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
     private ApiClientService apiClientService;
+    private DeliveryDetailsValidator deliveryDetailsValidator;
 
-    public CheckoutBasketValidator(ApiClientService apiClientService) {
+    public CheckoutBasketValidator(ApiClientService apiClientService, DeliveryDetailsValidator deliveryDetailsValidator) {
         this.apiClientService = apiClientService;
+        this.deliveryDetailsValidator = deliveryDetailsValidator;
     }
 
     public List<String> getValidationErrors(final Basket basket) {
@@ -33,9 +37,18 @@ public class CheckoutBasketValidator {
         else {
             String itemUri = "";
             try {
-                itemUri = basketItems.get(0).getItemUri();
+                Item item = basketItems.get(0);
+                itemUri = item.getItemUri();
                 LoggingUtils.logIfNotNull(logMap, LoggingUtils.ITEM_URI, itemUri);
-                
+
+                if (item.isPostalDelivery()) {
+                    if (!deliveryDetailsValidator.isValid(basket.getData().getDeliveryDetails())) {
+                        logMap.put(LoggingUtils.ERROR_TYPE, ErrorType.DELIVERY_DETAILS_MISSING.getValue());
+                        LOGGER.error(ErrorType.DELIVERY_DETAILS_MISSING.getValue(), logMap);
+                        errors.add(ErrorType.DELIVERY_DETAILS_MISSING.getValue());
+                    }
+                }
+
                 apiClientService.getItem(itemUri);
             } catch (Exception exception) {
                 logMap.put(LoggingUtils.EXCEPTION, exception);

--- a/src/main/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidator.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidator.java
@@ -41,15 +41,13 @@ public class CheckoutBasketValidator {
                 itemUri = item.getItemUri();
                 LoggingUtils.logIfNotNull(logMap, LoggingUtils.ITEM_URI, itemUri);
 
-                if (item.isPostalDelivery()) {
-                    if (!deliveryDetailsValidator.isValid(basket.getData().getDeliveryDetails())) {
-                        logMap.put(LoggingUtils.ERROR_TYPE, ErrorType.DELIVERY_DETAILS_MISSING.getValue());
-                        LOGGER.error(ErrorType.DELIVERY_DETAILS_MISSING.getValue(), logMap);
-                        errors.add(ErrorType.DELIVERY_DETAILS_MISSING.getValue());
-                    }
-                }
+                item = apiClientService.getItem(itemUri);
 
-                apiClientService.getItem(itemUri);
+                if (item.isPostalDelivery() && !deliveryDetailsValidator.isValid(basket.getData().getDeliveryDetails())) {
+                    logMap.put(LoggingUtils.ERROR_TYPE, ErrorType.DELIVERY_DETAILS_MISSING.getValue());
+                    LOGGER.error(ErrorType.DELIVERY_DETAILS_MISSING.getValue(), logMap);
+                    errors.add(ErrorType.DELIVERY_DETAILS_MISSING.getValue());
+                }
             } catch (Exception exception) {
                 logMap.put(LoggingUtils.EXCEPTION, exception);
                 logMap.put(LoggingUtils.ERROR_TYPE, ErrorType.BASKET_ITEM_INVALID.getValue());

--- a/src/main/java/uk/gov/companieshouse/orders/api/validator/DeliveryDetailsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/validator/DeliveryDetailsValidator.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.orders.api.validator;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.orders.api.dto.AddDeliveryDetailsRequestDTO;
+import uk.gov.companieshouse.orders.api.model.DeliveryDetails;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,5 +24,16 @@ public class DeliveryDetailsValidator {
         }
 
         return errors;
+    }
+
+    public boolean isValid(final DeliveryDetails deliveryDetails) {
+        return (deliveryDetails != null &&
+                StringUtils.isNotBlank(deliveryDetails.getAddressLine1()) &&
+                StringUtils.isNotBlank(deliveryDetails.getForename()) &&
+                StringUtils.isNotBlank(deliveryDetails.getSurname()) &&
+                StringUtils.isNotBlank(deliveryDetails.getCountry()) &&
+                StringUtils.isNotBlank(deliveryDetails.getLocality()) &&
+                (StringUtils.isNotBlank(deliveryDetails.getPostalCode()) ||
+                        StringUtils.isNotBlank(deliveryDetails.getRegion())));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/interceptor/OrdersApiAuthenticationTests.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/interceptor/OrdersApiAuthenticationTests.java
@@ -156,6 +156,7 @@ class OrdersApiAuthenticationTests {
 		certificate.setItemCosts(ITEM_COSTS);
 		certificate.setPostageCost(POSTAGE_COST);
 		certificate.setTotalItemCost(TOTAL_ITEM_COST);
+		certificate.setPostalDelivery(false);
 		final CertificateItemOptions options = new CertificateItemOptions();
 		options.setForename(FORENAME);
 		options.setSurname(SURNAME);

--- a/src/test/java/uk/gov/companieshouse/orders/api/interceptor/OrdersApiAuthenticationTests.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/interceptor/OrdersApiAuthenticationTests.java
@@ -147,6 +147,7 @@ class OrdersApiAuthenticationTests {
 		basket.setId(ERIC_IDENTITY_VALUE);
 		final Item basketItem = new Item();
 		basketItem.setItemUri(ITEM_URI);
+		basketItem.setPostalDelivery(false);
 		basket.getData().getItems().add(basketItem);
 		basket.getData().setDeliveryDetails(new DeliveryDetails());
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidatorTest.java
@@ -9,21 +9,34 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.orders.api.exception.ErrorType;
 import uk.gov.companieshouse.orders.api.model.Basket;
 import uk.gov.companieshouse.orders.api.model.BasketData;
+import uk.gov.companieshouse.orders.api.model.Certificate;
 import uk.gov.companieshouse.orders.api.model.DeliveryDetails;
 import uk.gov.companieshouse.orders.api.model.Item;
+import uk.gov.companieshouse.orders.api.model.ItemCosts;
 import uk.gov.companieshouse.orders.api.service.ApiClientService;
 
 import java.util.Collections;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.orders.api.model.ProductType.CERTIFICATE_ADDITIONAL_COPY;
+import static uk.gov.companieshouse.orders.api.model.ProductType.CERTIFICATE_SAME_DAY;
 
 @ExtendWith(MockitoExtension.class)
 public class CheckoutBasketValidatorTest {
+    private static final String ITEM_URI = "/orderable/certificates/12345678";
     private static final String INVALID_ITEM_URI = "invalid_uri";
+    private static final String COMPANY_NUMBER = "00000000";
+    private static final List<ItemCosts> ITEM_COSTS =
+            asList(new ItemCosts( "0", "50", "50", CERTIFICATE_SAME_DAY),
+                    new ItemCosts("40", "50", "10", CERTIFICATE_ADDITIONAL_COPY),
+                    new ItemCosts("40", "50", "10", CERTIFICATE_ADDITIONAL_COPY));
+    private static final String POSTAGE_COST = "0";
+    private static final String TOTAL_ITEM_COST = "70";
     @InjectMocks
     private CheckoutBasketValidator validatorUnderTest;
     @Mock
@@ -65,6 +78,13 @@ public class CheckoutBasketValidatorTest {
         // Given
         Basket basket = setupBasketWithMissingDeliveryDetails();
         // When
+        final Certificate certificate = new Certificate();
+        certificate.setCompanyNumber(COMPANY_NUMBER);
+        certificate.setItemCosts(ITEM_COSTS);
+        certificate.setPostageCost(POSTAGE_COST);
+        certificate.setTotalItemCost(TOTAL_ITEM_COST);
+        certificate.setPostalDelivery(true);
+        when(apiClientService.getItem(ITEM_URI)).thenReturn(certificate);
         List<String> errors = validatorUnderTest.getValidationErrors(basket);
         // Then
         assertThat(errors.isEmpty(), is(false));
@@ -78,6 +98,13 @@ public class CheckoutBasketValidatorTest {
         // Given
         Basket basket = setupBasketWithMissingAddressDetails();
         // When
+        final Certificate certificate = new Certificate();
+        certificate.setCompanyNumber(COMPANY_NUMBER);
+        certificate.setItemCosts(ITEM_COSTS);
+        certificate.setPostageCost(POSTAGE_COST);
+        certificate.setTotalItemCost(TOTAL_ITEM_COST);
+        certificate.setPostalDelivery(true);
+        when(apiClientService.getItem(ITEM_URI)).thenReturn(certificate);
         List<String> errors = validatorUnderTest.getValidationErrors(basket);
         // Then
         assertThat(errors.isEmpty(), is(false));
@@ -109,6 +136,7 @@ public class CheckoutBasketValidatorTest {
         Basket basket = new Basket();
         BasketData basketData = new BasketData();
         Item basketItem = new Item();
+        basketItem.setItemUri(ITEM_URI);
         basketItem.setPostalDelivery(true);
         basketData.setItems(Collections.singletonList(basketItem));
         basket.setData(basketData);
@@ -122,6 +150,7 @@ public class CheckoutBasketValidatorTest {
         DeliveryDetails deliveryDetails = new DeliveryDetails();
         basketData.setDeliveryDetails(deliveryDetails);
         Item basketItem = new Item();
+        basketItem.setItemUri(ITEM_URI);
         basketItem.setPostalDelivery(true);
         basketData.setItems(Collections.singletonList(basketItem));
         basket.setData(basketData);


### PR DESCRIPTION
Ensures delivery details are present when checkout requested for basket item that needs postal delivery.