### PR TITLE
Change Kafka log dir to where it has rw access for tests

### DIFF
--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -8,3 +8,4 @@ uk.gov.companieshouse.payments.api.payments: payments.service/payments
 spring.kafka.consumer.bootstrap-servers: ${spring.embedded.kafka.brokers}
 spring.kafka.producer.bootstrap-servers: ${spring.embedded.kafka.brokers}
 spring.kafka.consumer.auto-offset-reset: earliest
+log.dir=target/embedded-kafka


### PR DESCRIPTION
This is a fix for the Surefire plugin failure test. The failure was due to embedded Kafka's inability to access default log directory in /var folder. This property addition to tests allows Kafka to use a folder that is inside `target` folder giving it full access to read and write. 