### PR TITLE
Reset spring context before running embedded kafka integration tests

### DIFF
--- a/src/test/java/uk/gov/companieshouse/orders/api/OrdersApiApplicationTests.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/OrdersApiApplicationTests.java
@@ -3,7 +3,9 @@ package uk.gov.companieshouse.orders.api;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
 
+@DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EmbeddedKafka
 class OrdersApiApplicationTests {

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -96,6 +97,7 @@ import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_
 import static uk.gov.companieshouse.orders.api.util.TestConstants.REQUEST_ID_HEADER_NAME;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.TOKEN_REQUEST_ID_VALUE;
 
+@DirtiesContext
 @AutoConfigureMockMvc
 @SpringBootTest
 @EmbeddedKafka

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/HealthcheckControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/HealthcheckControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.orders.api.interceptor.UserAuthenticationInterceptor;
 
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@DirtiesContext
 @AutoConfigureMockMvc
 @SpringBootTest
 @EmbeddedKafka

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/OrderControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/OrderControllerIntegrationTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.orders.api.model.Order;
 import uk.gov.companieshouse.orders.api.model.OrderData;
@@ -19,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.companieshouse.orders.api.util.TestConstants.*;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_OAUTH2_TYPE_VALUE;
 
+@DirtiesContext
 @AutoConfigureMockMvc
 @SpringBootTest
 @EmbeddedKafka

--- a/src/test/java/uk/gov/companieshouse/orders/api/interceptor/OrdersApiAuthenticationTests.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/interceptor/OrdersApiAuthenticationTests.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import uk.gov.companieshouse.orders.api.dto.AddDeliveryDetailsRequestDTO;
 import uk.gov.companieshouse.orders.api.dto.AddToBasketRequestDTO;
@@ -43,6 +44,7 @@ import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_
 import static uk.gov.companieshouse.orders.api.util.TestConstants.REQUEST_ID_HEADER_NAME;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.TOKEN_REQUEST_ID_VALUE;
 
+@DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EmbeddedKafka
 class OrdersApiAuthenticationTests {

--- a/src/test/java/uk/gov/companieshouse/orders/api/interceptor/OrdersApiAuthorisationTests.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/interceptor/OrdersApiAuthorisationTests.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import uk.gov.companieshouse.orders.api.dto.AddToBasketRequestDTO;
 
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.web.reactive.function.BodyInserters.fromObject;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.*;
 
+@DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EmbeddedKafka
 public class OrdersApiAuthorisationTests {

--- a/src/test/java/uk/gov/companieshouse/orders/api/interceptor/RequestMapperTests.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/interceptor/RequestMapperTests.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpMethod;
 import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -20,6 +21,7 @@ import static uk.gov.companieshouse.orders.api.interceptor.RequestMapper.*;
 /**
  * Unit/integration tests the {@link RequestMapper} class.
  */
+@DirtiesContext
 @SpringBootTest
 @EmbeddedKafka
 public class RequestMapperTests {

--- a/src/test/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthenticationInterceptorTests.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthenticationInterceptorTests.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -23,6 +24,7 @@ import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_
 /**
  * Unit/integration tests the {@link UserAuthenticationInterceptor} class.
  */
+@DirtiesContext
 @SpringBootTest
 @EmbeddedKafka
 public class UserAuthenticationInterceptorTests {

--- a/src/test/java/uk/gov/companieshouse/orders/api/util/FieldNameConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/util/FieldNameConverterTest.java
@@ -5,10 +5,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+@DirtiesContext
 @SpringBootTest
 @EmbeddedKafka
 class FieldNameConverterTest {

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -8,4 +8,3 @@ uk.gov.companieshouse.payments.api.payments: payments.service/payments
 spring.kafka.consumer.bootstrap-servers: ${spring.embedded.kafka.brokers}
 spring.kafka.producer.bootstrap-servers: ${spring.embedded.kafka.brokers}
 spring.kafka.consumer.auto-offset-reset: earliest
-log.dir=target/embedded-kafka


### PR DESCRIPTION
This follows up the previous attempt to fix Surefire build issue by resetting Spring context before running each embedded Kafka integration test. The build failures were a result of Kafka log `.lock` file being contested for by each integration test thread. This change clears the context using the `@DirtiesContext` annotation.