### PR TITLE
GCI-1022: Add certified copy item to basket

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 		<!-- system-rules: 1.17.2 is the latest version that works with JUnit 5.
 			 See https://github.com/stefanbirkner/system-rules/issues/70 -->
 		<system-rules-version>1.17.2</system-rules-version>
+		<spring-cloud-contract-wiremock-version>2.2.2.RELEASE</spring-cloud-contract-wiremock-version>
 		<start-class>uk.gov.companieshouse.orders.api.OrdersApiApplication</start-class>
 		<!-- TODO GCI-1242 set private-api-sdk-java.version to 2.0.41+ -->
 		<private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
@@ -127,6 +128,12 @@
 			<groupId>com.github.stefanbirkner</groupId>
 			<artifactId>system-rules</artifactId>
 			<version>${system-rules-version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-contract-wiremock</artifactId>
+			<version>${spring-cloud-contract-wiremock-version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,7 @@
 		<system-rules-version>1.17.2</system-rules-version>
 		<spring-cloud-contract-wiremock-version>2.2.2.RELEASE</spring-cloud-contract-wiremock-version>
 		<start-class>uk.gov.companieshouse.orders.api.OrdersApiApplication</start-class>
-		<!-- TODO GCI-1242 set private-api-sdk-java.version to 2.0.41+ -->
-		<private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+		<private-api-sdk-java.version>2.0.42</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>1.0.3</api-sdk-manager-java-library.version>
 		<api-sdk-java.version>4.1.48</api-sdk-java.version>
 		<api-helper-java.version>1.4.1</api-helper-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,9 @@
 		<junit-jupiter-engine-version>5.2.0</junit-jupiter-engine-version>
 		<mockito-junit-jupiter-version>2.18.0</mockito-junit-jupiter-version>
 		<hamcrest-all-version>1.3</hamcrest-all-version>
+		<!-- system-rules: 1.17.2 is the latest version that works with JUnit 5.
+			 See https://github.com/stefanbirkner/system-rules/issues/70 -->
+		<system-rules-version>1.17.2</system-rules-version>
 		<start-class>uk.gov.companieshouse.orders.api.OrdersApiApplication</start-class>
 		<!-- TODO GCI-1242 set private-api-sdk-java.version to 2.0.41+ -->
 		<private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
@@ -118,6 +121,12 @@
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-all</artifactId>
 			<version>${hamcrest-all-version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.stefanbirkner</groupId>
+			<artifactId>system-rules</artifactId>
+			<version>${system-rules-version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,8 @@
 		<mockito-junit-jupiter-version>2.18.0</mockito-junit-jupiter-version>
 		<hamcrest-all-version>1.3</hamcrest-all-version>
 		<start-class>uk.gov.companieshouse.orders.api.OrdersApiApplication</start-class>
-		<private-api-sdk-java.version>2.0.27</private-api-sdk-java.version>
+		<!-- TODO GCI-1242 set private-api-sdk-java.version to 2.0.41+ -->
+		<private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>1.0.3</api-sdk-manager-java-library.version>
 		<api-sdk-java.version>4.1.48</api-sdk-java.version>
 		<api-helper-java.version>1.4.1</api-helper-java.version>

--- a/src/main/java/uk/gov/companieshouse/orders/api/dto/BasketItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/dto/BasketItemDTO.java
@@ -39,9 +39,6 @@ public class BasketItemDTO extends ItemDTO {
     @JsonProperty("etag")
     private String etag;
 
-    @JsonProperty("kind")
-    private String kind;
-
     @JsonProperty("links")
     private ItemLinks links;
 
@@ -110,14 +107,6 @@ public class BasketItemDTO extends ItemDTO {
 
     public void setEtag(String etag) {
         this.etag = etag;
-    }
-
-    public String getKind() {
-        return kind;
-    }
-
-    public void setKind(String kind) {
-        this.kind = kind;
     }
 
     public ItemLinks getLinks() {

--- a/src/main/java/uk/gov/companieshouse/orders/api/dto/BasketItemDTO.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/dto/BasketItemDTO.java
@@ -1,9 +1,9 @@
 package uk.gov.companieshouse.orders.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.companieshouse.orders.api.model.CertificateItemOptions;
 import uk.gov.companieshouse.orders.api.model.ItemCosts;
 import uk.gov.companieshouse.orders.api.model.ItemLinks;
+import uk.gov.companieshouse.orders.api.model.ItemOptions;
 
 import java.util.List;
 import java.util.Map;
@@ -34,7 +34,7 @@ public class BasketItemDTO extends ItemDTO {
     private List<ItemCosts> itemCosts;
 
     @JsonProperty("item_options")
-    private CertificateItemOptions itemOptions;
+    private ItemOptions itemOptions;
 
     @JsonProperty("etag")
     private String etag;
@@ -96,11 +96,11 @@ public class BasketItemDTO extends ItemDTO {
         this.itemCosts = itemCosts;
     }
 
-    public CertificateItemOptions getItemOptions() {
+    public ItemOptions getItemOptions() {
         return itemOptions;
     }
 
-    public void setItemOptions(CertificateItemOptions itemOptions) {
+    public void setItemOptions(ItemOptions itemOptions) {
         this.itemOptions = itemOptions;
     }
 

--- a/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapper.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapper.java
@@ -2,13 +2,22 @@ package uk.gov.companieshouse.orders.api.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
 import uk.gov.companieshouse.api.model.order.item.CertificateApi;
 import uk.gov.companieshouse.orders.api.model.Certificate;
+import uk.gov.companieshouse.orders.api.model.Item;
 
+// TODO GCI-1242 Rename class?
 @Mapper(componentModel = "spring")
 public interface ApiToCertificateMapper {
+    // TODO GCI-1242 Redundant?
     @Mapping(source = "links.self", target="itemUri")
     @Mapping(target = "satisfiedAt", ignore = true)
     @Mapping(target = "status", ignore = true)
     Certificate apiToCertificate(CertificateApi certificateApi);
+
+    @Mapping(source = "links.self", target="itemUri")
+    @Mapping(target = "satisfiedAt", ignore = true)
+    @Mapping(target = "status", ignore = true)
+    Item apiToItem(BaseItemApi baseItemApi);
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapper.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapper.java
@@ -20,10 +20,4 @@ public interface ApiToCertificateMapper {
 
     CertificateItemOptions apiOptionsToCertificateOptions(CertificateItemOptionsApi certificateOptionsApi);
     CertifiedCopyItemOptions apiOptionsToCertificateOptions(CertifiedCopyItemOptionsApi certifiedCopyOptionsApi);
-
-    // TODO GCI-1242 Redundant?
-    @Mapping(source = "links.self", target="itemUri")
-    @Mapping(target = "satisfiedAt", ignore = true)
-    @Mapping(target = "status", ignore = true)
-    Item apiToItem(BaseItemApi baseItemApi);
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapper.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapper.java
@@ -2,12 +2,8 @@ package uk.gov.companieshouse.orders.api.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
-import uk.gov.companieshouse.api.model.order.item.CertificateApi;
-import uk.gov.companieshouse.api.model.order.item.CertifiedCopyApi;
-import uk.gov.companieshouse.orders.api.model.Certificate;
-import uk.gov.companieshouse.orders.api.model.CertifiedCopy;
-import uk.gov.companieshouse.orders.api.model.Item;
+import uk.gov.companieshouse.api.model.order.item.*;
+import uk.gov.companieshouse.orders.api.model.*;
 
 // TODO GCI-1242 Rename class?
 @Mapper(componentModel = "spring")
@@ -21,6 +17,9 @@ public interface ApiToCertificateMapper {
     @Mapping(target = "satisfiedAt", ignore = true)
     @Mapping(target = "status", ignore = true)
     CertifiedCopy apiToCertifiedCopy(CertifiedCopyApi certificateApi);
+
+    CertificateItemOptions apiOptionsToCertificateOptions(CertificateItemOptionsApi certificateOptionsApi);
+    CertifiedCopyItemOptions apiOptionsToCertificateOptions(CertifiedCopyItemOptionsApi certifiedCopyOptionsApi);
 
     // TODO GCI-1242 Redundant?
     @Mapping(source = "links.self", target="itemUri")

--- a/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapper.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapper.java
@@ -4,18 +4,25 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
 import uk.gov.companieshouse.api.model.order.item.CertificateApi;
+import uk.gov.companieshouse.api.model.order.item.CertifiedCopyApi;
 import uk.gov.companieshouse.orders.api.model.Certificate;
+import uk.gov.companieshouse.orders.api.model.CertifiedCopy;
 import uk.gov.companieshouse.orders.api.model.Item;
 
 // TODO GCI-1242 Rename class?
 @Mapper(componentModel = "spring")
 public interface ApiToCertificateMapper {
-    // TODO GCI-1242 Redundant?
     @Mapping(source = "links.self", target="itemUri")
     @Mapping(target = "satisfiedAt", ignore = true)
     @Mapping(target = "status", ignore = true)
     Certificate apiToCertificate(CertificateApi certificateApi);
 
+    @Mapping(source = "links.self", target="itemUri")
+    @Mapping(target = "satisfiedAt", ignore = true)
+    @Mapping(target = "status", ignore = true)
+    CertifiedCopy apiToCertifiedCopy(CertifiedCopyApi certificateApi);
+
+    // TODO GCI-1242 Redundant?
     @Mapping(source = "links.self", target="itemUri")
     @Mapping(target = "satisfiedAt", ignore = true)
     @Mapping(target = "status", ignore = true)

--- a/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToItemMapper.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToItemMapper.java
@@ -8,6 +8,12 @@ import uk.gov.companieshouse.orders.api.model.*;
 @Mapper(componentModel = "spring")
 public interface ApiToItemMapper {
 
+    /**
+     * Uses the underlying type and fields of the Item API object provided to create a model class object of the
+     * appropriate type.
+     * @param baseItemApi the Item Api (SDK DTO) object obtained from an API
+     * @return an object of the corresponding model class, either a {@link Certificate}, or a {@link CertifiedCopy}
+     */
     default Item apiToItem(final BaseItemApi baseItemApi) {
         if (baseItemApi instanceof CertificateApi) {
             return apiToCertificate((CertificateApi) baseItemApi);

--- a/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToItemMapper.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToItemMapper.java
@@ -5,9 +5,8 @@ import org.mapstruct.Mapping;
 import uk.gov.companieshouse.api.model.order.item.*;
 import uk.gov.companieshouse.orders.api.model.*;
 
-// TODO GCI-1242 Rename class?
 @Mapper(componentModel = "spring")
-public interface ApiToCertificateMapper {
+public interface ApiToItemMapper {
     @Mapping(source = "links.self", target="itemUri")
     @Mapping(target = "satisfiedAt", ignore = true)
     @Mapping(target = "status", ignore = true)

--- a/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToItemMapper.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/mapper/ApiToItemMapper.java
@@ -7,6 +7,15 @@ import uk.gov.companieshouse.orders.api.model.*;
 
 @Mapper(componentModel = "spring")
 public interface ApiToItemMapper {
+
+    default Item apiToItem(final BaseItemApi baseItemApi) {
+        if (baseItemApi instanceof CertificateApi) {
+            return apiToCertificate((CertificateApi) baseItemApi);
+        } else {
+            return apiToCertifiedCopy((CertifiedCopyApi) baseItemApi);
+        }
+    }
+
     @Mapping(source = "links.self", target="itemUri")
     @Mapping(target = "satisfiedAt", ignore = true)
     @Mapping(target = "status", ignore = true)

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/Certificate.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/Certificate.java
@@ -1,4 +1,15 @@
 package uk.gov.companieshouse.orders.api.model;
 
 
-public class Certificate extends Item { }
+public class Certificate extends Item {
+
+    private CertificateItemOptions itemOptions;
+
+    public CertificateItemOptions getItemOptions() {
+        return itemOptions;
+    }
+
+    public void setItemOptions(CertificateItemOptions itemOptions) {
+        this.itemOptions = itemOptions;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/Certificate.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/Certificate.java
@@ -1,15 +1,4 @@
 package uk.gov.companieshouse.orders.api.model;
 
 
-public class Certificate extends Item {
-
-    private CertificateItemOptions itemOptions;
-
-    public CertificateItemOptions getItemOptions() {
-        return itemOptions;
-    }
-
-    public void setItemOptions(CertificateItemOptions itemOptions) {
-        this.itemOptions = itemOptions;
-    }
-}
+public class Certificate extends Item { }

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/CertificateItemOptions.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/CertificateItemOptions.java
@@ -1,20 +1,10 @@
 package uk.gov.companieshouse.orders.api.model;
 
-public class CertificateItemOptions {
+public class CertificateItemOptions extends ItemOptions {
 
     private CertificateType certificateType;
 
-    private CollectionLocation collectionLocation;
-
-    private String contactNumber;
-
-    private DeliveryMethod deliveryMethod;
-
-    private DeliveryTimescale deliveryTimescale;
-
     private DirectorOrSecretaryDetails directorDetails;
-
-    private String forename;
 
     private Boolean includeCompanyObjectsInformation;
 
@@ -26,8 +16,6 @@ public class CertificateItemOptions {
 
     private DirectorOrSecretaryDetails secretaryDetails;
 
-    private String surname;
-
     public CertificateType getCertificateType() {
         return certificateType;
     }
@@ -36,37 +24,6 @@ public class CertificateItemOptions {
         this.certificateType = certificateType;
     }
 
-    public CollectionLocation getCollectionLocation() {
-        return collectionLocation;
-    }
-
-    public void setCollectionLocation(CollectionLocation collectionLocation) {
-        this.collectionLocation = collectionLocation;
-    }
-
-    public String getContactNumber() {
-        return contactNumber;
-    }
-
-    public void setContactNumber(String contactNumber) {
-        this.contactNumber = contactNumber;
-    }
-
-    public DeliveryMethod getDeliveryMethod() {
-        return deliveryMethod;
-    }
-
-    public void setDeliveryMethod(DeliveryMethod deliveryMethod) {
-        this.deliveryMethod = deliveryMethod;
-    }
-
-    public DeliveryTimescale getDeliveryTimescale() {
-        return deliveryTimescale;
-    }
-
-    public void setDeliveryTimescale(DeliveryTimescale deliveryTimescale) {
-        this.deliveryTimescale = deliveryTimescale;
-    }
 
     public DirectorOrSecretaryDetails getDirectorDetails() {
         return directorDetails;
@@ -74,14 +31,6 @@ public class CertificateItemOptions {
 
     public void setDirectorDetails(DirectorOrSecretaryDetails directorOrSecretaryDetails) {
         this.directorDetails = directorOrSecretaryDetails;
-    }
-
-    public String getForename() {
-        return forename;
-    }
-
-    public void setForename(String forename) {
-        this.forename = forename;
     }
 
     public Boolean getIncludeCompanyObjectsInformation() {
@@ -124,11 +73,4 @@ public class CertificateItemOptions {
         this.secretaryDetails = secretaryDetails;
     }
 
-    public String getSurname() {
-        return surname;
-    }
-
-    public void setSurname(String surname) {
-        this.surname = surname;
-    }
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/CertifiedCopy.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/CertifiedCopy.java
@@ -1,4 +1,15 @@
 package uk.gov.companieshouse.orders.api.model;
 
 
-public class CertifiedCopy extends Item { }
+public class CertifiedCopy extends Item {
+
+    private CertifiedCopyItemOptions itemOptions;
+
+    public CertifiedCopyItemOptions getItemOptions() {
+        return itemOptions;
+    }
+
+    public void setItemOptions(CertifiedCopyItemOptions itemOptions) {
+        this.itemOptions = itemOptions;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/CertifiedCopy.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/CertifiedCopy.java
@@ -1,15 +1,4 @@
 package uk.gov.companieshouse.orders.api.model;
 
 
-public class CertifiedCopy extends Item {
-
-    private CertifiedCopyItemOptions itemOptions;
-
-    public CertifiedCopyItemOptions getItemOptions() {
-        return itemOptions;
-    }
-
-    public void setItemOptions(CertifiedCopyItemOptions itemOptions) {
-        this.itemOptions = itemOptions;
-    }
-}
+public class CertifiedCopy extends Item { }

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/CertifiedCopy.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/CertifiedCopy.java
@@ -1,0 +1,4 @@
+package uk.gov.companieshouse.orders.api.model;
+
+
+public class CertifiedCopy extends Item { }

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/CertifiedCopyItemOptions.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/CertifiedCopyItemOptions.java
@@ -1,0 +1,16 @@
+package uk.gov.companieshouse.orders.api.model;
+
+import java.util.List;
+
+public class CertifiedCopyItemOptions extends ItemOptions {
+
+    private List<FilingHistoryDocument> filingHistoryDocuments;
+
+    public List<FilingHistoryDocument> getFilingHistoryDocuments() {
+        return filingHistoryDocuments;
+    }
+
+    public void setFilingHistoryDocuments(List<FilingHistoryDocument> filingHistoryDocuments) {
+        this.filingHistoryDocuments = filingHistoryDocuments;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/FilingHistoryDocument.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/FilingHistoryDocument.java
@@ -1,0 +1,75 @@
+package uk.gov.companieshouse.orders.api.model;
+
+import com.google.gson.Gson;
+
+import java.util.Map;
+
+public class FilingHistoryDocument {
+
+    public FilingHistoryDocument() {}
+
+    public FilingHistoryDocument(final String filingHistoryDate,
+                                 final String filingHistoryDescription,
+                                 final Map<String, Object> filingHistoryDescriptionValues,
+                                 final String filingHistoryId,
+                                 final String filingHistoryType) {
+        this.filingHistoryDate = filingHistoryDate;
+        this.filingHistoryDescription = filingHistoryDescription;
+        this.filingHistoryDescriptionValues = filingHistoryDescriptionValues;
+        this.filingHistoryId = filingHistoryId;
+        this.filingHistoryType = filingHistoryType;
+    }
+
+    private String filingHistoryDate;
+
+    private String filingHistoryDescription;
+
+    private Map<String, Object> filingHistoryDescriptionValues;
+
+    private String filingHistoryId;
+
+    private String filingHistoryType;
+
+    public String getFilingHistoryDate() {
+        return filingHistoryDate;
+    }
+
+    public void setFilingHistoryDate(String filingHistoryDate) {
+        this.filingHistoryDate = filingHistoryDate;
+    }
+
+    public String getFilingHistoryDescription() {
+        return filingHistoryDescription;
+    }
+
+    public void setFilingHistoryDescription(String filingHistoryDescription) {
+        this.filingHistoryDescription = filingHistoryDescription;
+    }
+
+    public Map<String, Object> getFilingHistoryDescriptionValues() {
+        return filingHistoryDescriptionValues;
+    }
+
+    public void setFilingHistoryDescriptionValues(Map<String, Object> filingHistoryDescriptionValues) {
+        this.filingHistoryDescriptionValues = filingHistoryDescriptionValues;
+    }
+
+    public String getFilingHistoryId() {
+        return filingHistoryId;
+    }
+
+    public void setFilingHistoryId(String filingHistoryId) {
+        this.filingHistoryId = filingHistoryId;
+    }
+
+    public String getFilingHistoryType() {
+        return filingHistoryType;
+    }
+
+    public void setFilingHistoryType(String filingHistoryType) {
+        this.filingHistoryType = filingHistoryType;
+    }
+
+    @Override
+    public String toString() { return new Gson().toJson(this); }
+}

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/Item.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/Item.java
@@ -25,8 +25,7 @@ public class Item {
 
     private List<ItemCosts> itemCosts;
 
-    // TODO GCI-1242 Can we do this?
-//    private ItemOptions itemOptions;
+    private ItemOptions itemOptions;
 
     private String etag;
 
@@ -112,14 +111,13 @@ public class Item {
         this.itemCosts = itemCosts;
     }
 
-// TODO GCI-1242 Can we do this?
-//    public ItemOptions getItemOptions() {
-//        return itemOptions;
-//    }
-//
-//    public void setItemOptions(ItemOptions itemOptions) {
-//        this.itemOptions = itemOptions;
-//    }
+    public ItemOptions getItemOptions() {
+        return itemOptions;
+    }
+
+    public void setItemOptions(ItemOptions itemOptions) {
+        this.itemOptions = itemOptions;
+    }
 
     public String getEtag() {
         return etag;

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/Item.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/Item.java
@@ -25,7 +25,8 @@ public class Item {
 
     private List<ItemCosts> itemCosts;
 
-    private CertificateItemOptions itemOptions;
+    // TODO GCI-1242 Can we do this?
+//    private ItemOptions itemOptions;
 
     private String etag;
 
@@ -111,13 +112,14 @@ public class Item {
         this.itemCosts = itemCosts;
     }
 
-    public CertificateItemOptions getItemOptions() {
-        return itemOptions;
-    }
-
-    public void setItemOptions(CertificateItemOptions itemOptions) {
-        this.itemOptions = itemOptions;
-    }
+// TODO GCI-1242 Can we do this?
+//    public ItemOptions getItemOptions() {
+//        return itemOptions;
+//    }
+//
+//    public void setItemOptions(ItemOptions itemOptions) {
+//        this.itemOptions = itemOptions;
+//    }
 
     public String getEtag() {
         return etag;

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/ItemOptions.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/ItemOptions.java
@@ -1,0 +1,64 @@
+package uk.gov.companieshouse.orders.api.model;
+
+public class ItemOptions {
+
+    private CollectionLocation collectionLocation;
+
+    private String contactNumber;
+
+    private DeliveryMethod deliveryMethod;
+
+    private DeliveryTimescale deliveryTimescale;
+
+    private String forename;
+
+    private String surname;
+
+    public CollectionLocation getCollectionLocation() {
+        return collectionLocation;
+    }
+
+    public void setCollectionLocation(CollectionLocation collectionLocation) {
+        this.collectionLocation = collectionLocation;
+    }
+
+    public String getContactNumber() {
+        return contactNumber;
+    }
+
+    public void setContactNumber(String contactNumber) {
+        this.contactNumber = contactNumber;
+    }
+
+    public DeliveryMethod getDeliveryMethod() {
+        return deliveryMethod;
+    }
+
+    public void setDeliveryMethod(DeliveryMethod deliveryMethod) {
+        this.deliveryMethod = deliveryMethod;
+    }
+
+    public DeliveryTimescale getDeliveryTimescale() {
+        return deliveryTimescale;
+    }
+
+    public void setDeliveryTimescale(DeliveryTimescale deliveryTimescale) {
+        this.deliveryTimescale = deliveryTimescale;
+    }
+
+    public String getForename() {
+        return forename;
+    }
+
+    public void setForename(String forename) {
+        this.forename = forename;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
@@ -33,7 +33,7 @@ public class ApiClientService {
         this.apiClient = apiClient;
     }
 
-    public Item getItem(String itemUri) throws Exception {
+    public Item getItem(String itemUri) throws ApiErrorResponseException {
         final BaseItemApi baseItemApi;
         try {
             baseItemApi = apiClient

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
@@ -4,11 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriTemplate;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
-import uk.gov.companieshouse.api.handler.order.item.request.PrivateItemURIPattern;
-import uk.gov.companieshouse.api.handler.regex.URIValidator;
 import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
-import uk.gov.companieshouse.api.model.order.item.CertificateApi;
-import uk.gov.companieshouse.api.model.order.item.CertifiedCopyApi;
 import uk.gov.companieshouse.api.model.payment.PaymentApi;
 import uk.gov.companieshouse.orders.api.client.Api;
 import uk.gov.companieshouse.orders.api.exception.ServiceException;
@@ -46,11 +42,7 @@ public class ApiClientService {
             throw new ServiceException("Unrecognised uri pattern for " + itemUri);
         }
 
-        // TODO GCI-1242 Do this properly - either by URI or by examination of JSON response.
-        final Item item = URIValidator.validate(PrivateItemURIPattern.getCertificatesPattern(), itemUri) ?
-                apiToItemMapper.apiToCertificate((CertificateApi) baseItemApi) :
-                apiToItemMapper.apiToCertifiedCopy((CertifiedCopyApi) baseItemApi);
-
+        final Item item = apiToItemMapper.apiToItem(baseItemApi);
         item.setItemUri(itemUri);
         item.setStatus(ItemStatus.UNKNOWN);
         return item;

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
@@ -12,7 +12,7 @@ import uk.gov.companieshouse.api.model.order.item.CertifiedCopyApi;
 import uk.gov.companieshouse.api.model.payment.PaymentApi;
 import uk.gov.companieshouse.orders.api.client.Api;
 import uk.gov.companieshouse.orders.api.exception.ServiceException;
-import uk.gov.companieshouse.orders.api.mapper.ApiToCertificateMapper;
+import uk.gov.companieshouse.orders.api.mapper.ApiToItemMapper;
 import uk.gov.companieshouse.orders.api.model.Item;
 import uk.gov.companieshouse.orders.api.model.ItemStatus;
 
@@ -21,15 +21,15 @@ import java.io.IOException;
 @Service
 public class ApiClientService {
 
-    private final ApiToCertificateMapper apiToCertificateMapper;
+    private final ApiToItemMapper apiToItemMapper;
 
     private final Api apiClient;
 
     private static final UriTemplate GET_PAYMENT_URI =
             new UriTemplate("/payments/{paymentId}");
 
-    public ApiClientService(ApiToCertificateMapper apiToCertificateMapper, Api apiClient) {
-        this.apiToCertificateMapper = apiToCertificateMapper;
+    public ApiClientService(ApiToItemMapper apiToItemMapper, Api apiClient) {
+        this.apiToItemMapper = apiToItemMapper;
         this.apiClient = apiClient;
     }
 
@@ -46,8 +46,8 @@ public class ApiClientService {
             // TODO GCI-1242 Do this properly - either by URI or by examination of JSON response.
             // TODO GCI-1242 Validation rejection could fall out of this?
             final Item item = URIValidator.validate(PrivateItemURIPattern.getCertificatesPattern(), itemUri) ?
-                    apiToCertificateMapper.apiToCertificate((CertificateApi) baseItemApi) :
-                    apiToCertificateMapper.apiToCertifiedCopy((CertifiedCopyApi) baseItemApi);
+                    apiToItemMapper.apiToCertificate((CertificateApi) baseItemApi) :
+                    apiToItemMapper.apiToCertifiedCopy((CertifiedCopyApi) baseItemApi);
 
             item.setItemUri(itemUri);
             item.setStatus(ItemStatus.UNKNOWN);

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
@@ -6,7 +6,7 @@ import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.handler.order.item.request.PrivateItemURIPattern;
 import uk.gov.companieshouse.api.handler.regex.URIValidator;
-import uk.gov.companieshouse.api.model.order.item.CertificateApi;
+import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
 import uk.gov.companieshouse.api.model.payment.PaymentApi;
 import uk.gov.companieshouse.orders.api.client.Api;
 import uk.gov.companieshouse.orders.api.exception.ServiceException;
@@ -32,12 +32,18 @@ public class ApiClientService {
     }
 
     public Item getItem(String itemUri) throws Exception {
-        if (URIValidator.validate(PrivateItemURIPattern.getCertificatesPattern(), itemUri)) {
-            CertificateApi certificateApi = apiClient.getInternalApiClient().privateItemResourceHandler().getCertificate(itemUri).execute().getData();
-            Item certificate = apiToCertificateMapper.apiToCertificate(certificateApi);
-            certificate.setItemUri(itemUri);
-            certificate.setStatus(ItemStatus.UNKNOWN);
-            return certificate;
+        if (URIValidator.validate(PrivateItemURIPattern.getCertificatesPattern(), itemUri) ||
+            URIValidator.validate(PrivateItemURIPattern.getCertifiedCopyPattern(), itemUri)) {
+            final BaseItemApi baseItemApi = apiClient
+                    .getInternalApiClient()
+                    .privateItemResourceHandler()
+                    .getCertificate(itemUri)
+                    .execute()
+                    .getData();
+            final Item item = apiToCertificateMapper.apiToItem(baseItemApi);
+            item.setItemUri(itemUri);
+            item.setStatus(ItemStatus.UNKNOWN);
+            return item;
         } else {
             throw new ServiceException("Unrecognised uri pattern for "+itemUri);
         }

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
@@ -39,7 +39,7 @@ public class ApiClientService {
             final BaseItemApi baseItemApi = apiClient
                     .getInternalApiClient()
                     .privateItemResourceHandler()
-                    .getCertificate(itemUri)
+                    .getItem(itemUri)
                     .execute()
                     .getData();
 

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
@@ -9,6 +9,8 @@ import uk.gov.companieshouse.api.model.payment.PaymentApi;
 import uk.gov.companieshouse.orders.api.client.Api;
 import uk.gov.companieshouse.orders.api.exception.ServiceException;
 import uk.gov.companieshouse.orders.api.mapper.ApiToItemMapper;
+import uk.gov.companieshouse.orders.api.model.Certificate;
+import uk.gov.companieshouse.orders.api.model.CertifiedCopy;
 import uk.gov.companieshouse.orders.api.model.Item;
 import uk.gov.companieshouse.orders.api.model.ItemStatus;
 
@@ -29,6 +31,12 @@ public class ApiClientService {
         this.apiClient = apiClient;
     }
 
+    /**
+     * Gets an item from a remote API by sending it a get item HTTP GET request.
+     * @param itemUri the URI path representing the item (and implicitly the type of item) sought
+     * @return the item (either a {@link Certificate}, or a {@link CertifiedCopy})
+     * @throws ApiErrorResponseException should there be a 4xx or 5xx response from the API
+     */
     public Item getItem(String itemUri) throws ApiErrorResponseException {
         final BaseItemApi baseItemApi;
         try {

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/ApiClientService.java
@@ -7,6 +7,8 @@ import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.handler.order.item.request.PrivateItemURIPattern;
 import uk.gov.companieshouse.api.handler.regex.URIValidator;
 import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
+import uk.gov.companieshouse.api.model.order.item.CertificateApi;
+import uk.gov.companieshouse.api.model.order.item.CertifiedCopyApi;
 import uk.gov.companieshouse.api.model.payment.PaymentApi;
 import uk.gov.companieshouse.orders.api.client.Api;
 import uk.gov.companieshouse.orders.api.exception.ServiceException;
@@ -40,7 +42,13 @@ public class ApiClientService {
                     .getCertificate(itemUri)
                     .execute()
                     .getData();
-            final Item item = apiToCertificateMapper.apiToItem(baseItemApi);
+
+            // TODO GCI-1242 Do this properly - either by URI or by examination of JSON response.
+            // TODO GCI-1242 Validation rejection could fall out of this?
+            final Item item = URIValidator.validate(PrivateItemURIPattern.getCertificatesPattern(), itemUri) ?
+                    apiToCertificateMapper.apiToCertificate((CertificateApi) baseItemApi) :
+                    apiToCertificateMapper.apiToCertifiedCopy((CertifiedCopyApi) baseItemApi);
+
             item.setItemUri(itemUri);
             item.setStatus(ItemStatus.UNKNOWN);
             return item;

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -647,6 +647,9 @@ class BasketControllerIntegrationTest {
         certificate.setSatisfiedAt(SATISFIED_AT);
         certificate.setPostageCost(POSTAGE_COST);
         certificate.setTotalItemCost(TOTAL_ITEM_COST);
+        final CertificateItemOptions options = new CertificateItemOptions();
+        options.setCertificateType(INCORPORATION_WITH_ALL_NAME_CHANGES);
+        certificate.setItemOptions(options);
         when(apiClientService.getItem(VALID_CERTIFICATE_URI)).thenReturn(certificate);
 
         final String jsonResponse = mockMvc.perform(get("/basket")
@@ -655,6 +658,8 @@ class BasketControllerIntegrationTest {
                 .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].item_options.certificate_type",
+                        is(INCORPORATION_WITH_ALL_NAME_CHANGES.getJsonName())))
                 .andReturn().getResponse().getContentAsString();
 
         final BasketData response = mapper.readValue(jsonResponse, BasketData.class);

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -37,6 +37,7 @@ import uk.gov.companieshouse.orders.api.model.CheckoutData;
 import uk.gov.companieshouse.orders.api.model.DeliveryDetails;
 import uk.gov.companieshouse.orders.api.model.Item;
 import uk.gov.companieshouse.orders.api.model.ItemCosts;
+import uk.gov.companieshouse.orders.api.model.ItemOptions;
 import uk.gov.companieshouse.orders.api.model.Order;
 import uk.gov.companieshouse.orders.api.model.PaymentStatus;
 import uk.gov.companieshouse.orders.api.repository.BasketRepository;
@@ -342,47 +343,46 @@ class BasketControllerIntegrationTest {
         assertFalse(retrievedBasket.isPresent());
     }
 
-    // TODO GCI-1242 Restore this test
-//    @Test
-//    @DisplayName("Checkout basket successfully creates checkout, when basket contains a valid certificate uri")
-//    public void checkoutBasketSuccessfullyCreatesCheckoutWhenBasketIsValid() throws Exception {
-//        basketRepository.save(getBasket(false));
-//
-//        Certificate certificate = new Certificate();
-//        certificate.setCompanyNumber(COMPANY_NUMBER);
-//        final CertificateItemOptions options = new CertificateItemOptions();
-//        options.setForename(FORENAME);
-//        options.setSurname(SURNAME);
-//        certificate.setItemOptions(options);
-//        certificate.setItemCosts(createItemCosts());
-//        certificate.setPostageCost(POSTAGE_COST);
-//        certificate.setPostalDelivery(false);
-//        when(apiClientService.getItem(ITEM_URI)).thenReturn(certificate);
-//
-//        ResultActions resultActions = mockMvc.perform(post("/basket/checkouts")
-//                .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
-//                .header(ERIC_IDENTITY_TYPE_HEADER_NAME, ERIC_IDENTITY_OAUTH2_TYPE_VALUE)
-//                .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
-//                .header(ERIC_AUTHORISED_USER_HEADER_NAME, ERIC_AUTHORISED_USER_VALUE))
-//                .andExpect(status().isAccepted());
-//
-//        MvcResult result = resultActions.andReturn();
-//        MockHttpServletResponse response = result.getResponse();
-//        assertThat(response.getHeader(PAYMENT_REQUIRED_HEADER), is(COSTS_LINK));
-//        String contentAsString = response.getContentAsString();
-//        CheckoutData responseCheckoutData = mapper.readValue(contentAsString, CheckoutData.class);
-//
-//        final Optional<Checkout> retrievedCheckout = checkoutRepository.findById(responseCheckoutData.getReference());
-//        assertTrue(retrievedCheckout.isPresent());
-//        assertEquals(ERIC_IDENTITY_VALUE, retrievedCheckout.get().getUserId());
-//        final CheckoutData checkoutData = retrievedCheckout.get().getData();
-//        final Item item = checkoutData.getItems().get(0);
-//        assertEquals(COMPANY_NUMBER, item.getCompanyNumber());
-//        final CertificateItemOptions retrievedOptions = item.getItemOptions();
-//        assertEquals(FORENAME, retrievedOptions.getForename());
-//        assertEquals(SURNAME, retrievedOptions.getSurname());
-//        assertEquals(EXPECTED_TOTAL_ORDER_COST, checkoutData.getTotalOrderCost());
-//    }
+    @Test
+    @DisplayName("Checkout basket successfully creates checkout, when basket contains a valid certificate uri")
+    public void checkoutBasketSuccessfullyCreatesCheckoutWhenBasketIsValid() throws Exception {
+        basketRepository.save(getBasket(false));
+
+        Certificate certificate = new Certificate();
+        certificate.setCompanyNumber(COMPANY_NUMBER);
+        final CertificateItemOptions options = new CertificateItemOptions();
+        options.setForename(FORENAME);
+        options.setSurname(SURNAME);
+        certificate.setItemOptions(options);
+        certificate.setItemCosts(createItemCosts());
+        certificate.setPostageCost(POSTAGE_COST);
+        certificate.setPostalDelivery(false);
+        when(apiClientService.getItem(ITEM_URI)).thenReturn(certificate);
+
+        ResultActions resultActions = mockMvc.perform(post("/basket/checkouts")
+                .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
+                .header(ERIC_IDENTITY_TYPE_HEADER_NAME, ERIC_IDENTITY_OAUTH2_TYPE_VALUE)
+                .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
+                .header(ERIC_AUTHORISED_USER_HEADER_NAME, ERIC_AUTHORISED_USER_VALUE))
+                .andExpect(status().isAccepted());
+
+        MvcResult result = resultActions.andReturn();
+        MockHttpServletResponse response = result.getResponse();
+        assertThat(response.getHeader(PAYMENT_REQUIRED_HEADER), is(COSTS_LINK));
+        String contentAsString = response.getContentAsString();
+        CheckoutData responseCheckoutData = mapper.readValue(contentAsString, CheckoutData.class);
+
+        final Optional<Checkout> retrievedCheckout = checkoutRepository.findById(responseCheckoutData.getReference());
+        assertTrue(retrievedCheckout.isPresent());
+        assertEquals(ERIC_IDENTITY_VALUE, retrievedCheckout.get().getUserId());
+        final CheckoutData checkoutData = retrievedCheckout.get().getData();
+        final Item item = checkoutData.getItems().get(0);
+        assertEquals(COMPANY_NUMBER, item.getCompanyNumber());
+        final ItemOptions retrievedOptions = item.getItemOptions();
+        assertEquals(FORENAME, retrievedOptions.getForename());
+        assertEquals(SURNAME, retrievedOptions.getSurname());
+        assertEquals(EXPECTED_TOTAL_ORDER_COST, checkoutData.getTotalOrderCost());
+    }
 
     private Basket getBasket(boolean isPostalDelivery) {
         Basket basket = new Basket();

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -614,8 +614,8 @@ class BasketControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("Return a populated basket using GET method")
-    void getBasketReturnsPopulatedBasket() throws Exception {
+    @DisplayName("Get basket successfully returns a basket populated with a certificate")
+    void getBasketReturnsBasketPopulatedWithCertificate() throws Exception {
         final LocalDateTime start = timestamps.start();
         Basket basket = createBasket(start);
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -342,46 +342,47 @@ class BasketControllerIntegrationTest {
         assertFalse(retrievedBasket.isPresent());
     }
 
-    @Test
-    @DisplayName("Checkout basket successfully creates checkout, when basket contains a valid certificate uri")
-    public void checkoutBasketSuccessfullyCreatesCheckoutWhenBasketIsValid() throws Exception {
-        basketRepository.save(getBasket(false));
-
-        Certificate certificate = new Certificate();
-        certificate.setCompanyNumber(COMPANY_NUMBER);
-        final CertificateItemOptions options = new CertificateItemOptions();
-        options.setForename(FORENAME);
-        options.setSurname(SURNAME);
-        certificate.setItemOptions(options);
-        certificate.setItemCosts(createItemCosts());
-        certificate.setPostageCost(POSTAGE_COST);
-        certificate.setPostalDelivery(false);
-        when(apiClientService.getItem(ITEM_URI)).thenReturn(certificate);
-
-        ResultActions resultActions = mockMvc.perform(post("/basket/checkouts")
-                .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
-                .header(ERIC_IDENTITY_TYPE_HEADER_NAME, ERIC_IDENTITY_OAUTH2_TYPE_VALUE)
-                .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
-                .header(ERIC_AUTHORISED_USER_HEADER_NAME, ERIC_AUTHORISED_USER_VALUE))
-                .andExpect(status().isAccepted());
-
-        MvcResult result = resultActions.andReturn();
-        MockHttpServletResponse response = result.getResponse();
-        assertThat(response.getHeader(PAYMENT_REQUIRED_HEADER), is(COSTS_LINK));
-        String contentAsString = response.getContentAsString();
-        CheckoutData responseCheckoutData = mapper.readValue(contentAsString, CheckoutData.class);
-
-        final Optional<Checkout> retrievedCheckout = checkoutRepository.findById(responseCheckoutData.getReference());
-        assertTrue(retrievedCheckout.isPresent());
-        assertEquals(ERIC_IDENTITY_VALUE, retrievedCheckout.get().getUserId());
-        final CheckoutData checkoutData = retrievedCheckout.get().getData();
-        final Item item = checkoutData.getItems().get(0);
-        assertEquals(COMPANY_NUMBER, item.getCompanyNumber());
-        final CertificateItemOptions retrievedOptions = item.getItemOptions();
-        assertEquals(FORENAME, retrievedOptions.getForename());
-        assertEquals(SURNAME, retrievedOptions.getSurname());
-        assertEquals(EXPECTED_TOTAL_ORDER_COST, checkoutData.getTotalOrderCost());
-    }
+    // TODO GCI-1242 Restore this test
+//    @Test
+//    @DisplayName("Checkout basket successfully creates checkout, when basket contains a valid certificate uri")
+//    public void checkoutBasketSuccessfullyCreatesCheckoutWhenBasketIsValid() throws Exception {
+//        basketRepository.save(getBasket(false));
+//
+//        Certificate certificate = new Certificate();
+//        certificate.setCompanyNumber(COMPANY_NUMBER);
+//        final CertificateItemOptions options = new CertificateItemOptions();
+//        options.setForename(FORENAME);
+//        options.setSurname(SURNAME);
+//        certificate.setItemOptions(options);
+//        certificate.setItemCosts(createItemCosts());
+//        certificate.setPostageCost(POSTAGE_COST);
+//        certificate.setPostalDelivery(false);
+//        when(apiClientService.getItem(ITEM_URI)).thenReturn(certificate);
+//
+//        ResultActions resultActions = mockMvc.perform(post("/basket/checkouts")
+//                .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
+//                .header(ERIC_IDENTITY_TYPE_HEADER_NAME, ERIC_IDENTITY_OAUTH2_TYPE_VALUE)
+//                .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
+//                .header(ERIC_AUTHORISED_USER_HEADER_NAME, ERIC_AUTHORISED_USER_VALUE))
+//                .andExpect(status().isAccepted());
+//
+//        MvcResult result = resultActions.andReturn();
+//        MockHttpServletResponse response = result.getResponse();
+//        assertThat(response.getHeader(PAYMENT_REQUIRED_HEADER), is(COSTS_LINK));
+//        String contentAsString = response.getContentAsString();
+//        CheckoutData responseCheckoutData = mapper.readValue(contentAsString, CheckoutData.class);
+//
+//        final Optional<Checkout> retrievedCheckout = checkoutRepository.findById(responseCheckoutData.getReference());
+//        assertTrue(retrievedCheckout.isPresent());
+//        assertEquals(ERIC_IDENTITY_VALUE, retrievedCheckout.get().getUserId());
+//        final CheckoutData checkoutData = retrievedCheckout.get().getData();
+//        final Item item = checkoutData.getItems().get(0);
+//        assertEquals(COMPANY_NUMBER, item.getCompanyNumber());
+//        final CertificateItemOptions retrievedOptions = item.getItemOptions();
+//        assertEquals(FORENAME, retrievedOptions.getForename());
+//        assertEquals(SURNAME, retrievedOptions.getSurname());
+//        assertEquals(EXPECTED_TOTAL_ORDER_COST, checkoutData.getTotalOrderCost());
+//    }
 
     private Basket getBasket(boolean isPostalDelivery) {
         Basket basket = new Basket();

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -652,16 +652,6 @@ class BasketControllerIntegrationTest {
         final LocalDateTime start = timestamps.start();
         Basket basket = createBasket(start);
 
-        DeliveryDetails deliveryDetails = new DeliveryDetails();
-        deliveryDetails.setAddressLine1(ADDRESS_LINE_1);
-        deliveryDetails.setAddressLine2(ADDRESS_LINE_2);
-        deliveryDetails.setCountry(COUNTRY);
-        deliveryDetails.setForename(FORENAME);
-        deliveryDetails.setSurname(SURNAME);
-        deliveryDetails.setLocality(LOCALITY);
-
-        basket.getData().setDeliveryDetails(deliveryDetails);
-
         basketRepository.save(basket);
 
         final Certificate certificate = new Certificate();
@@ -722,7 +712,7 @@ class BasketControllerIntegrationTest {
         assertEquals(POSTAGE_COST, item.getPostageCost());
         assertEquals(TOTAL_ITEM_COST, item.getTotalItemCost());
 
-        verifyBasketIsUnchanged(start, deliveryDetails, VALID_CERTIFICATE_URI);
+        verifyBasketIsUnchanged(start, basket.getData().getDeliveryDetails(), VALID_CERTIFICATE_URI);
     }
 
     @Test
@@ -730,15 +720,6 @@ class BasketControllerIntegrationTest {
     void getBasketReturnsBasketPopulatedWithCertifiedCopy() throws Exception {
         final LocalDateTime start = timestamps.start();
         final Basket basket = createBasket(start, VALID_CERTIFIED_COPY_URI);
-
-        final DeliveryDetails deliveryDetails = new DeliveryDetails();
-        deliveryDetails.setAddressLine1(ADDRESS_LINE_1);
-        deliveryDetails.setAddressLine2(ADDRESS_LINE_2);
-        deliveryDetails.setCountry(COUNTRY);
-        deliveryDetails.setForename(FORENAME);
-        deliveryDetails.setSurname(SURNAME);
-        deliveryDetails.setLocality(LOCALITY);
-        basket.getData().setDeliveryDetails(deliveryDetails);
 
         basketRepository.save(basket);
 
@@ -806,7 +787,7 @@ class BasketControllerIntegrationTest {
         assertEquals(POSTAGE_COST, item.getPostageCost());
         assertEquals(TOTAL_ITEM_COST, item.getTotalItemCost());
 
-        verifyBasketIsUnchanged(start, deliveryDetails, VALID_CERTIFIED_COPY_URI);
+        verifyBasketIsUnchanged(start, basket.getData().getDeliveryDetails(), VALID_CERTIFIED_COPY_URI);
     }
 
     @Test
@@ -1389,8 +1370,7 @@ class BasketControllerIntegrationTest {
     }
 
     /**
-     * Verifies that the basket is as it was when created by {@link #createBasket(LocalDateTime, String)}, plus
-     * the addition of delivery details.
+     * Verifies that the basket is as it was when created by {@link #createBasket(LocalDateTime, String)}.
      * @param basketCreationTime the time the basket was created
      * @param deliveryDetailsAdded the delivery details added to the basket
      * @param itemUri the URI of the item stored in the basket
@@ -1411,9 +1391,11 @@ class BasketControllerIntegrationTest {
     }
 
     /**
-     * Creates a basket containing a certificate item with just its item URI member populated. In this way,
-     * it creates a basket in the database that is similar to what results when
-     * {@link BasketController#addItemToBasket(AddToBasketRequestDTO, HttpServletRequest, String)} is called.
+     * Creates a basket containing an item with just its item URI member populated, and some delivery details.
+     * In this way, it creates a basket in the database that is similar to what results when
+     * {@link BasketController#addItemToBasket(AddToBasketRequestDTO, HttpServletRequest, String)} and
+     * {@link BasketController#addDeliveryDetailsToBasket(AddDeliveryDetailsRequestDTO, HttpServletRequest, String)}
+     * have been called.
      * @param start the creation/update time of the basket
      * @return the {@link Basket} as persisted in the database
      */
@@ -1422,9 +1404,11 @@ class BasketControllerIntegrationTest {
     }
 
     /**
-     * Creates a basket containing an item with just its item URI member populated. In this way, it creates a basket in
-     * the database that is similar to what results when
-     * {@link BasketController#addItemToBasket(AddToBasketRequestDTO, HttpServletRequest, String)} is called.
+     * Creates a basket containing an item with just its item URI member populated, and some delivery details.
+     * In this way, it creates a basket in the database that is similar to what results when
+     * {@link BasketController#addItemToBasket(AddToBasketRequestDTO, HttpServletRequest, String)} and
+     * {@link BasketController#addDeliveryDetailsToBasket(AddDeliveryDetailsRequestDTO, HttpServletRequest, String)}
+     * have been called.
      * @param start the creation/update time of the basket
      * @param itemUri the URI of the item stored in the basket
      * @return the {@link Basket} as persisted in the database
@@ -1437,6 +1421,17 @@ class BasketControllerIntegrationTest {
         Item basketItem = new Item();
         basketItem.setItemUri(itemUri);
         basket.getData().getItems().add(basketItem);
+
+        DeliveryDetails deliveryDetails = new DeliveryDetails();
+        deliveryDetails.setAddressLine1(ADDRESS_LINE_1);
+        deliveryDetails.setAddressLine2(ADDRESS_LINE_2);
+        deliveryDetails.setCountry(COUNTRY);
+        deliveryDetails.setForename(FORENAME);
+        deliveryDetails.setSurname(SURNAME);
+        deliveryDetails.setLocality(LOCALITY);
+
+        basket.getData().setDeliveryDetails(deliveryDetails);
+
         return basketRepository.save(basket);
     }
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -297,13 +297,13 @@ class BasketControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsString(addToBasketRequestDTO)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.item_options.filing_history_documents.[0].filing_history_date",
+                .andExpect(jsonPath("$.item_options.filing_history_documents[0].filing_history_date",
                         is(DOCUMENT.getFilingHistoryDate())))
-                .andExpect(jsonPath("$.item_options.filing_history_documents.[0].filing_history_description",
+                .andExpect(jsonPath("$.item_options.filing_history_documents[0].filing_history_description",
                         is(DOCUMENT.getFilingHistoryDescription())))
-                .andExpect(jsonPath("$.item_options.filing_history_documents.[0].filing_history_id",
+                .andExpect(jsonPath("$.item_options.filing_history_documents[0].filing_history_id",
                         is(DOCUMENT.getFilingHistoryId())))
-                .andExpect(jsonPath("$.item_options.filing_history_documents.[0].filing_history_type",
+                .andExpect(jsonPath("$.item_options.filing_history_documents[0].filing_history_type",
                         is(DOCUMENT.getFilingHistoryType())));
 
         final Optional<Basket> retrievedBasket = basketRepository.findById(ERIC_IDENTITY_VALUE);
@@ -736,13 +736,13 @@ class BasketControllerIntegrationTest {
                 .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.items[0].item_options.filing_history_documents.[0].filing_history_date",
+                .andExpect(jsonPath("$.items[0].item_options.filing_history_documents[0].filing_history_date",
                         is(DOCUMENT.getFilingHistoryDate())))
-                .andExpect(jsonPath("$.items[0].item_options.filing_history_documents.[0].filing_history_description",
+                .andExpect(jsonPath("$.items[0].item_options.filing_history_documents[0].filing_history_description",
                         is(DOCUMENT.getFilingHistoryDescription())))
-                .andExpect(jsonPath("$.items[0].item_options.filing_history_documents.[0].filing_history_id",
+                .andExpect(jsonPath("$.items[0].item_options.filing_history_documents[0].filing_history_id",
                         is(DOCUMENT.getFilingHistoryId())))
-                .andExpect(jsonPath("$.items[0].item_options.filing_history_documents.[0].filing_history_type",
+                .andExpect(jsonPath("$.items[0].item_options.filing_history_documents[0].filing_history_type",
                         is(DOCUMENT.getFilingHistoryType())))
                 .andReturn().getResponse().getContentAsString();
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -38,6 +38,7 @@ import uk.gov.companieshouse.orders.api.util.TimestampedEntityVerifier;
 import uk.gov.companieshouse.orders.api.validator.DeliveryDetailsValidator;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.Month;
@@ -1264,6 +1265,13 @@ class BasketControllerIntegrationTest {
         return checkoutService.createCheckout(item, ERIC_IDENTITY_VALUE, ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
     }
 
+    /**
+     * Creates a basket containing an item with just its item URI member populated. In this way, it creates a basket in
+     * the database that is similar to what results when
+     * {@link BasketController#addItemToBasket(AddToBasketRequestDTO, HttpServletRequest, String)} is called.
+     * @param start the creation/update time of the basket
+     * @return the {@link Basket} as persisted in the database
+     */
     private Basket createBasket(LocalDateTime start) {
         final Basket basket = new Basket();
         basket.setCreatedAt(start);
@@ -1271,23 +1279,7 @@ class BasketControllerIntegrationTest {
         basket.setId(ERIC_IDENTITY_VALUE);
         Item basketItem = new Item();
         basketItem.setItemUri(VALID_CERTIFICATE_URI);
-        basketItem.setCompanyName(COMPANY_NAME);
-        basketItem.setCompanyNumber(COMPANY_NUMBER);
-        basketItem.setCustomerReference(CUSTOMER_REFERENCE);
-        basketItem.setDescription(DESCRIPTION);
-        basketItem.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
-        basketItem.setDescriptionValues(DESCRIPTION_VALUES);
-        basketItem.setItemCosts(ITEM_COSTS);
-        basketItem.setEtag(ETAG);
-        basketItem.setKind(KIND);
-        basketItem.setPostalDelivery(POSTAL_DELIVERY);
-        basketItem.setQuantity(QUANTITY);
-        basketItem.setSatisfiedAt(SATISFIED_AT);
-        basketItem.setPostageCost(POSTAGE_COST);
-        basketItem.setTotalItemCost(TOTAL_ITEM_COST);
-
         basket.getData().getItems().add(basketItem);
-
         return basketRepository.save(basket);
     }
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.model.payment.PaymentApi;
 import uk.gov.companieshouse.orders.api.dto.AddDeliveryDetailsRequestDTO;
 import uk.gov.companieshouse.orders.api.dto.AddToBasketRequestDTO;
@@ -167,6 +169,9 @@ class BasketControllerIntegrationTest {
     private DeliveryDetailsValidator deliveryDetailsValidator;
 
     private TimestampedEntityVerifier timestamps;
+
+    @Mock
+    private ApiErrorResponseException apiErrorResponseException;
 
     @BeforeEach
     void setUp() {
@@ -323,7 +328,7 @@ class BasketControllerIntegrationTest {
 
         AddToBasketRequestDTO addToBasketRequestDTO = new AddToBasketRequestDTO();
         addToBasketRequestDTO.setItemUri(INVALID_ITEM_URI);
-        when(apiClientService.getItem(anyString())).thenThrow(new Exception());
+        when(apiClientService.getItem(anyString())).thenThrow(apiErrorResponseException);
 
         final ApiError expectedValidationError =
                 new ApiError(BAD_REQUEST,
@@ -547,7 +552,7 @@ class BasketControllerIntegrationTest {
     public void checkoutBasketFailsToCreateCheckoutWhenItFailsToGetAnItem() throws Exception {
         basketRepository.save(getBasket(false));
 
-        when(apiClientService.getItem(VALID_CERTIFICATE_URI)).thenThrow(new Exception());
+        when(apiClientService.getItem(VALID_CERTIFICATE_URI)).thenThrow(apiErrorResponseException);
 
         mockMvc.perform(post("/basket/checkouts")
                 .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
@@ -925,7 +930,7 @@ class BasketControllerIntegrationTest {
         deliveryDetailsDTO.setSurname(SURNAME);
         addDeliveryDetailsRequestDTO.setDeliveryDetails(deliveryDetailsDTO);
 
-        when(apiClientService.getItem(anyString())).thenThrow(new Exception());
+        when(apiClientService.getItem(anyString())).thenThrow(apiErrorResponseException);
 
         final ApiError expectedValidationError =
                 new ApiError(BAD_REQUEST,
@@ -949,7 +954,7 @@ class BasketControllerIntegrationTest {
         basket.setId(ERIC_IDENTITY_VALUE);
         basketRepository.save(basket);
 
-        when(apiClientService.getItem(null)).thenThrow(new Exception());
+        when(apiClientService.getItem(null)).thenThrow(apiErrorResponseException);
         final ApiError expectedValidationError =
                 new ApiError(CONFLICT,
                         asList(ErrorType.BASKET_ITEMS_MISSING.getValue()));
@@ -1004,7 +1009,7 @@ class BasketControllerIntegrationTest {
         basket.getData().setItems(Collections.singletonList(basketItem));
         basketRepository.save(basket);
 
-        when(apiClientService.getItem(anyString())).thenThrow(new Exception());
+        when(apiClientService.getItem(anyString())).thenThrow(apiErrorResponseException);
 
         final ApiError expectedValidationError =
                 new ApiError(BAD_REQUEST,

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -227,11 +227,11 @@ class BasketControllerIntegrationTest {
 
         final Optional<Basket> retrievedBasket = basketRepository.findById(ERIC_IDENTITY_VALUE);
         assertEquals(ITEM_URI, retrievedBasket.get().getData().getItems().get(0).getItemUri());
-        assertThat(COMPANY_NUMBER, is(basketItemDTOResp.getCompanyNumber()));
-        assertThat(DISCOUNT_APPLIED_1, is(basketItemDTOResp.getItemCosts().get(0).getDiscountApplied()));
-        assertThat(ITEM_COST_1, is(basketItemDTOResp.getItemCosts().get(0).getItemCost()));
-        assertThat(CALCULATED_COST_1, is(basketItemDTOResp.getItemCosts().get(0).getCalculatedCost()));
-        assertThat(POSTAGE_COST, is(basketItemDTOResp.getPostageCost()));
+        assertThat(basketItemDTOResp.getCompanyNumber(), is(COMPANY_NUMBER));
+        assertThat(basketItemDTOResp.getItemCosts().get(0).getDiscountApplied(), is(DISCOUNT_APPLIED_1));
+        assertThat(basketItemDTOResp.getItemCosts().get(0).getItemCost(), is(ITEM_COST_1));
+        assertThat(basketItemDTOResp.getItemCosts().get(0).getCalculatedCost(), is(CALCULATED_COST_1));
+        assertThat(basketItemDTOResp.getPostageCost(), is(POSTAGE_COST));
         assertEquals(1, retrievedBasket.get().getData().getItems().size());
     }
 
@@ -264,11 +264,11 @@ class BasketControllerIntegrationTest {
         BasketItemDTO basketItemDTOResp = mapper.readValue(contentAsString, BasketItemDTO.class);
 
         final Optional<Basket> retrievedBasket = basketRepository.findById(ERIC_IDENTITY_VALUE);
-        assertThat(COMPANY_NUMBER, is(basketItemDTOResp.getCompanyNumber()));
-        assertThat(DISCOUNT_APPLIED_1, is(basketItemDTOResp.getItemCosts().get(0).getDiscountApplied()));
-        assertThat(ITEM_COST_1, is(basketItemDTOResp.getItemCosts().get(0).getItemCost()));
-        assertThat(CALCULATED_COST_1, is(basketItemDTOResp.getItemCosts().get(0).getCalculatedCost()));
-        assertThat(POSTAGE_COST, is(basketItemDTOResp.getPostageCost()));
+        assertThat(basketItemDTOResp.getCompanyNumber(), is(COMPANY_NUMBER));
+        assertThat(basketItemDTOResp.getItemCosts().get(0).getDiscountApplied(), is(DISCOUNT_APPLIED_1));
+        assertThat(basketItemDTOResp.getItemCosts().get(0).getItemCost(), is(ITEM_COST_1));
+        assertThat(basketItemDTOResp.getItemCosts().get(0).getCalculatedCost(), is(CALCULATED_COST_1));
+        assertThat(basketItemDTOResp.getPostageCost(), is(POSTAGE_COST));
         assertEquals(ITEM_URI, retrievedBasket.get().getData().getItems().get(0).getItemUri());
     }
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -618,8 +618,6 @@ class BasketControllerIntegrationTest {
         final LocalDateTime start = timestamps.start();
         Basket basket = createBasket(start);
 
-        BasketData basketData = new BasketData();
-
         DeliveryDetails deliveryDetails = new DeliveryDetails();
         deliveryDetails.setAddressLine1(ADDRESS_LINE_1);
         deliveryDetails.setAddressLine2(ADDRESS_LINE_2);
@@ -633,24 +631,37 @@ class BasketControllerIntegrationTest {
         basketRepository.save(basket);
 
         final Certificate certificate = new Certificate();
+        certificate.setItemUri(VALID_CERTIFICATE_URI);
         certificate.setCompanyNumber(COMPANY_NUMBER);
+        certificate.setCompanyName(COMPANY_NAME);
+        certificate.setCustomerReference(CUSTOMER_REFERENCE);
+        certificate.setDescription(DESCRIPTION);
+        certificate.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
+        certificate.setDescriptionValues(DESCRIPTION_VALUES);
         certificate.setItemCosts(ITEM_COSTS);
+        certificate.setEtag(ETAG);
+        certificate.setKind(KIND);
+        certificate.setPostalDelivery(POSTAL_DELIVERY);
+        certificate.setQuantity(QUANTITY);
+        certificate.setSatisfiedAt(SATISFIED_AT);
         certificate.setPostageCost(POSTAGE_COST);
         certificate.setTotalItemCost(TOTAL_ITEM_COST);
-
-        mockMvc.perform(get("/basket")
-            .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
-            .header(ERIC_IDENTITY_TYPE_HEADER_NAME, ERIC_IDENTITY_OAUTH2_TYPE_VALUE)
-            .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk());
-
-
-        final Optional<Basket> retrievedBasket = basketRepository.findById(ERIC_IDENTITY_VALUE);
         when(apiClientService.getItem(VALID_CERTIFICATE_URI)).thenReturn(certificate);
 
-        final DeliveryDetails getDeliveryDetails = retrievedBasket.get().getData().getDeliveryDetails();
-        final Item item = retrievedBasket.get().getData().getItems().get(0);
+        final String jsonResponse = mockMvc.perform(get("/basket")
+                .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
+                .header(ERIC_IDENTITY_TYPE_HEADER_NAME, ERIC_IDENTITY_OAUTH2_TYPE_VALUE)
+                .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        // TODO GCI-1022 Should this be making any assertions about the retrieved basket?
+        // final Optional<Basket> retrievedBasket = basketRepository.findById(ERIC_IDENTITY_VALUE);
+        final BasketData response = mapper.readValue(jsonResponse, BasketData.class);
+
+        final DeliveryDetails getDeliveryDetails = response.getDeliveryDetails();
+        final Item item = response.getItems().get(0);
         assertEquals(ADDRESS_LINE_1, getDeliveryDetails.getAddressLine1());
         assertEquals(ADDRESS_LINE_2, getDeliveryDetails.getAddressLine2());
         assertEquals(COUNTRY, getDeliveryDetails.getCountry());

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -75,16 +75,7 @@ import static uk.gov.companieshouse.api.util.security.SecurityConstants.INTERNAL
 import static uk.gov.companieshouse.orders.api.model.CertificateType.INCORPORATION_WITH_ALL_NAME_CHANGES;
 import static uk.gov.companieshouse.orders.api.model.ProductType.CERTIFICATE_ADDITIONAL_COPY;
 import static uk.gov.companieshouse.orders.api.model.ProductType.CERTIFICATE_SAME_DAY;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_ACCESS_TOKEN;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_AUTHORISED_USER_HEADER_NAME;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_AUTHORISED_USER_VALUE;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_API_KEY_TYPE_VALUE;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_HEADER_NAME;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_OAUTH2_TYPE_VALUE;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_TYPE_HEADER_NAME;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_VALUE;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.REQUEST_ID_HEADER_NAME;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.TOKEN_REQUEST_ID_VALUE;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.*;
 
 @AutoConfigureMockMvc
 @SpringBootTest
@@ -147,13 +138,6 @@ class BasketControllerIntegrationTest {
     private static final String PAYMENT_KIND = "payment-details#payment-details";
     private static final String UPDATED_ETAG = "dc3b9657a32453c6f79d5f3981bfa9af0a8b5478";
     private static final LocalDateTime PAID_AT_DATE = LocalDateTime.of(2020, Month.JANUARY, 1, 0, 0);
-    private static final FilingHistoryDocument DOCUMENT = new FilingHistoryDocument(
-            "1993-04-01",
-            "memorandum-articles",
-            null,
-            "MDAxMTEyNzExOGFkaXF6a2N4",
-            "MEM/ARTS"
-    );
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.model.payment.PaymentApi;
 import uk.gov.companieshouse.orders.api.dto.BasketPaymentRequestDTO;
 import uk.gov.companieshouse.orders.api.model.Basket;
@@ -100,7 +101,7 @@ class BasketControllerTest {
         basket.get().getData().setItems(items);
 
         when(basketService.getBasketById(any())).thenReturn(basket);
-        when(apiClientService.getItem(any())).thenThrow(Exception.class);
+        when(apiClientService.getItem(any())).thenThrow(ApiErrorResponseException.class);
 
         ResponseEntity<?> responseEntity = controllerUnderTest.getBasket(httpServletRequest, "requestId");
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapperTest.java
@@ -108,48 +108,49 @@ public class ApiToCertificateMapperTest {
 
     }
 
-    // TODO GCI-1242 Restore this test
-//    @Test
-//    public void testCertificateApiToCertificate() {
-//        CertificateApi certificateApi = new CertificateApi();
-//        certificateApi.setId(ID);
-//        certificateApi.setCompanyName(COMPANY_NAME);
-//        certificateApi.setCompanyNumber(COMPANY_NUMBER);
-//        certificateApi.setCustomerReference(CUSTOMER_REFERENCE);
-//        certificateApi.setQuantity(QUANTITY);
-//        certificateApi.setDescription(DESCRIPTION);
-//        certificateApi.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
-//        certificateApi.setDescriptionValues(DESCRIPTION_VALUES);
-//        certificateApi.setItemCosts(singletonList(ITEM_COSTS));
-//        certificateApi.setKind(KIND);
-//        certificateApi.setPostalDelivery(POSTAL_DELIVERY);
-//        certificateApi.setItemOptions(ITEM_OPTIONS);
-//        certificateApi.setLinks(LINKS_API);
-//        certificateApi.setPostageCost(POSTAGE_COST);
-//        certificateApi.setTotalItemCost(TOTAL_ITEM_COST);
-//
-//        final Certificate certificate = apiToCertificateMapper.apiToCertificate(certificateApi);
-//
-//        assertEquals(certificateApi.getId(), certificate.getId());
-//        assertThat(certificate.getId(), is(certificateApi.getId()));
-//        assertThat(certificate.getCompanyName(), is(certificateApi.getCompanyName()));
-//        assertThat(certificate.getCompanyNumber(), is(certificateApi.getCompanyNumber()));
-//        assertThat(certificate.getCustomerReference(), is(certificateApi.getCustomerReference()));
-//        assertThat(certificate.getQuantity(), is(certificateApi.getQuantity()));
-//        assertThat(certificate.getDescription(), is(certificateApi.getDescription()));
-//        assertThat(certificate.getDescriptionIdentifier(), is(certificateApi.getDescriptionIdentifier()));
-//        assertThat(certificate.getDescriptionValues(), is(certificateApi.getDescriptionValues()));
-//        assertThat(certificate.getKind(), is(certificateApi.getKind()));
-//        assertThat(certificate.isPostalDelivery(), is(certificateApi.isPostalDelivery()));
-//        assertThat(certificate.getEtag(), is(certificateApi.getEtag()));
-//        assertThat(certificate.getItemUri(), is(certificateApi.getLinks().getSelf()));
-//        assertThat(certificate.getLinks().getSelf(), is(certificateApi.getLinks().getSelf()));
-//
-//        assertItemCosts(certificateApi.getItemCosts().get(0), certificate.getItemCosts().get(0));
-//        assertItemOptionsSame(certificateApi.getItemOptions(), certificate.getItemOptions());
-//        assertThat(certificate.getPostageCost(), is(certificateApi.getPostageCost()));
-//        assertThat(certificate.getTotalItemCost(), is(certificateApi.getTotalItemCost()));
-//    }
+    @Test
+    public void testCertificateApiToCertificate() {
+        CertificateApi certificateApi = new CertificateApi();
+        certificateApi.setId(ID);
+        certificateApi.setCompanyName(COMPANY_NAME);
+        certificateApi.setCompanyNumber(COMPANY_NUMBER);
+        certificateApi.setCustomerReference(CUSTOMER_REFERENCE);
+        certificateApi.setQuantity(QUANTITY);
+        certificateApi.setDescription(DESCRIPTION);
+        certificateApi.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
+        certificateApi.setDescriptionValues(DESCRIPTION_VALUES);
+        certificateApi.setItemCosts(singletonList(ITEM_COSTS));
+        certificateApi.setKind(KIND);
+        certificateApi.setPostalDelivery(POSTAL_DELIVERY);
+        certificateApi.setItemOptions(ITEM_OPTIONS);
+        certificateApi.setLinks(LINKS_API);
+        certificateApi.setPostageCost(POSTAGE_COST);
+        certificateApi.setTotalItemCost(TOTAL_ITEM_COST);
+
+        final Certificate certificate = apiToCertificateMapper.apiToCertificate(certificateApi);
+
+        assertEquals(certificateApi.getId(), certificate.getId());
+        assertThat(certificate.getId(), is(certificateApi.getId()));
+        assertThat(certificate.getCompanyName(), is(certificateApi.getCompanyName()));
+        assertThat(certificate.getCompanyNumber(), is(certificateApi.getCompanyNumber()));
+        assertThat(certificate.getCustomerReference(), is(certificateApi.getCustomerReference()));
+        assertThat(certificate.getQuantity(), is(certificateApi.getQuantity()));
+        assertThat(certificate.getDescription(), is(certificateApi.getDescription()));
+        assertThat(certificate.getDescriptionIdentifier(), is(certificateApi.getDescriptionIdentifier()));
+        assertThat(certificate.getDescriptionValues(), is(certificateApi.getDescriptionValues()));
+        assertThat(certificate.getKind(), is(certificateApi.getKind()));
+        assertThat(certificate.isPostalDelivery(), is(certificateApi.isPostalDelivery()));
+        assertThat(certificate.getEtag(), is(certificateApi.getEtag()));
+        assertThat(certificate.getItemUri(), is(certificateApi.getLinks().getSelf()));
+        assertThat(certificate.getLinks().getSelf(), is(certificateApi.getLinks().getSelf()));
+
+        assertItemCosts(certificateApi.getItemCosts().get(0), certificate.getItemCosts().get(0));
+        assertItemOptionsSame(certificateApi.getItemOptions(), (CertificateItemOptions) certificate.getItemOptions());
+        assertThat(certificate.getPostageCost(), is(certificateApi.getPostageCost()));
+        assertThat(certificate.getTotalItemCost(), is(certificateApi.getTotalItemCost()));
+    }
+
+    // TODO GCI-1242 Implement test for certified copy mapping.
 
     private void assertItemCosts(final ItemCostsApi itemCostsApi, final ItemCosts itemCosts) {
         assertThat(itemCosts.getDiscountApplied(), is(itemCostsApi.getDiscountApplied()));

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToCertificateMapperTest.java
@@ -108,47 +108,48 @@ public class ApiToCertificateMapperTest {
 
     }
 
-    @Test
-    public void testCertificateApiToCertificate() {
-        CertificateApi certificateApi = new CertificateApi();
-        certificateApi.setId(ID);
-        certificateApi.setCompanyName(COMPANY_NAME);
-        certificateApi.setCompanyNumber(COMPANY_NUMBER);
-        certificateApi.setCustomerReference(CUSTOMER_REFERENCE);
-        certificateApi.setQuantity(QUANTITY);
-        certificateApi.setDescription(DESCRIPTION);
-        certificateApi.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
-        certificateApi.setDescriptionValues(DESCRIPTION_VALUES);
-        certificateApi.setItemCosts(singletonList(ITEM_COSTS));
-        certificateApi.setKind(KIND);
-        certificateApi.setPostalDelivery(POSTAL_DELIVERY);
-        certificateApi.setItemOptions(ITEM_OPTIONS);
-        certificateApi.setLinks(LINKS_API);
-        certificateApi.setPostageCost(POSTAGE_COST);
-        certificateApi.setTotalItemCost(TOTAL_ITEM_COST);
-
-        final Certificate certificate = apiToCertificateMapper.apiToCertificate(certificateApi);
-
-        assertEquals(certificateApi.getId(), certificate.getId());
-        assertThat(certificate.getId(), is(certificateApi.getId()));
-        assertThat(certificate.getCompanyName(), is(certificateApi.getCompanyName()));
-        assertThat(certificate.getCompanyNumber(), is(certificateApi.getCompanyNumber()));
-        assertThat(certificate.getCustomerReference(), is(certificateApi.getCustomerReference()));
-        assertThat(certificate.getQuantity(), is(certificateApi.getQuantity()));
-        assertThat(certificate.getDescription(), is(certificateApi.getDescription()));
-        assertThat(certificate.getDescriptionIdentifier(), is(certificateApi.getDescriptionIdentifier()));
-        assertThat(certificate.getDescriptionValues(), is(certificateApi.getDescriptionValues()));
-        assertThat(certificate.getKind(), is(certificateApi.getKind()));
-        assertThat(certificate.isPostalDelivery(), is(certificateApi.isPostalDelivery()));
-        assertThat(certificate.getEtag(), is(certificateApi.getEtag()));
-        assertThat(certificate.getItemUri(), is(certificateApi.getLinks().getSelf()));
-        assertThat(certificate.getLinks().getSelf(), is(certificateApi.getLinks().getSelf()));
-
-        assertItemCosts(certificateApi.getItemCosts().get(0), certificate.getItemCosts().get(0));
-        assertItemOptionsSame(certificateApi.getItemOptions(), certificate.getItemOptions());
-        assertThat(certificate.getPostageCost(), is(certificateApi.getPostageCost()));
-        assertThat(certificate.getTotalItemCost(), is(certificateApi.getTotalItemCost()));
-    }
+    // TODO GCI-1242 Restore this test
+//    @Test
+//    public void testCertificateApiToCertificate() {
+//        CertificateApi certificateApi = new CertificateApi();
+//        certificateApi.setId(ID);
+//        certificateApi.setCompanyName(COMPANY_NAME);
+//        certificateApi.setCompanyNumber(COMPANY_NUMBER);
+//        certificateApi.setCustomerReference(CUSTOMER_REFERENCE);
+//        certificateApi.setQuantity(QUANTITY);
+//        certificateApi.setDescription(DESCRIPTION);
+//        certificateApi.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
+//        certificateApi.setDescriptionValues(DESCRIPTION_VALUES);
+//        certificateApi.setItemCosts(singletonList(ITEM_COSTS));
+//        certificateApi.setKind(KIND);
+//        certificateApi.setPostalDelivery(POSTAL_DELIVERY);
+//        certificateApi.setItemOptions(ITEM_OPTIONS);
+//        certificateApi.setLinks(LINKS_API);
+//        certificateApi.setPostageCost(POSTAGE_COST);
+//        certificateApi.setTotalItemCost(TOTAL_ITEM_COST);
+//
+//        final Certificate certificate = apiToCertificateMapper.apiToCertificate(certificateApi);
+//
+//        assertEquals(certificateApi.getId(), certificate.getId());
+//        assertThat(certificate.getId(), is(certificateApi.getId()));
+//        assertThat(certificate.getCompanyName(), is(certificateApi.getCompanyName()));
+//        assertThat(certificate.getCompanyNumber(), is(certificateApi.getCompanyNumber()));
+//        assertThat(certificate.getCustomerReference(), is(certificateApi.getCustomerReference()));
+//        assertThat(certificate.getQuantity(), is(certificateApi.getQuantity()));
+//        assertThat(certificate.getDescription(), is(certificateApi.getDescription()));
+//        assertThat(certificate.getDescriptionIdentifier(), is(certificateApi.getDescriptionIdentifier()));
+//        assertThat(certificate.getDescriptionValues(), is(certificateApi.getDescriptionValues()));
+//        assertThat(certificate.getKind(), is(certificateApi.getKind()));
+//        assertThat(certificate.isPostalDelivery(), is(certificateApi.isPostalDelivery()));
+//        assertThat(certificate.getEtag(), is(certificateApi.getEtag()));
+//        assertThat(certificate.getItemUri(), is(certificateApi.getLinks().getSelf()));
+//        assertThat(certificate.getLinks().getSelf(), is(certificateApi.getLinks().getSelf()));
+//
+//        assertItemCosts(certificateApi.getItemCosts().get(0), certificate.getItemCosts().get(0));
+//        assertItemOptionsSame(certificateApi.getItemOptions(), certificate.getItemOptions());
+//        assertThat(certificate.getPostageCost(), is(certificateApi.getPostageCost()));
+//        assertThat(certificate.getTotalItemCost(), is(certificateApi.getTotalItemCost()));
+//    }
 
     private void assertItemCosts(final ItemCostsApi itemCostsApi, final ItemCosts itemCosts) {
         assertThat(itemCosts.getDiscountApplied(), is(itemCostsApi.getDiscountApplied()));

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToItemMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToItemMapperTest.java
@@ -20,8 +20,8 @@ import static org.junit.Assert.assertEquals;
 import static uk.gov.companieshouse.api.model.order.item.ProductTypeApi.CERTIFICATE;
 
 @ExtendWith(SpringExtension.class)
-@SpringJUnitConfig(ApiToCertificateMapperTest.Config.class)
-public class ApiToCertificateMapperTest {
+@SpringJUnitConfig(ApiToItemMapperTest.Config.class)
+public class ApiToItemMapperTest {
     private static final String ID = "CHS00000000000000001";
     private static final String COMPANY_NUMBER = "00006444";
     private static final int QUANTITY = 10;
@@ -62,11 +62,11 @@ public class ApiToCertificateMapperTest {
     private static final LinksApi LINKS_API;
 
     @Configuration
-    @ComponentScan(basePackageClasses = ApiToCertificateMapperTest.class)
+    @ComponentScan(basePackageClasses = ApiToItemMapperTest.class)
     static class Config {}
 
     @Autowired
-    private ApiToCertificateMapper apiToCertificateMapper;
+    private ApiToItemMapper apiToItemMapper;
 
     static {
         ITEM_COSTS = new ItemCostsApi();
@@ -127,7 +127,7 @@ public class ApiToCertificateMapperTest {
         certificateApi.setPostageCost(POSTAGE_COST);
         certificateApi.setTotalItemCost(TOTAL_ITEM_COST);
 
-        final Certificate certificate = apiToCertificateMapper.apiToCertificate(certificateApi);
+        final Certificate certificate = apiToItemMapper.apiToCertificate(certificateApi);
 
         assertEquals(certificateApi.getId(), certificate.getId());
         assertThat(certificate.getId(), is(certificateApi.getId()));

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToItemMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/ApiToItemMapperTest.java
@@ -157,7 +157,9 @@ public class ApiToItemMapperTest {
         certificateApi.setPostageCost(POSTAGE_COST);
         certificateApi.setTotalItemCost(TOTAL_ITEM_COST);
 
-        final Certificate certificate = apiToItemMapper.apiToCertificate(certificateApi);
+        final Item item = apiToItemMapper.apiToItem(certificateApi);
+        assertThat(item instanceof Certificate, is(true));
+        final Certificate certificate = (Certificate) item;
 
         assertEquals(certificateApi.getId(), certificate.getId());
         assertThat(certificate.getId(), is(certificateApi.getId()));
@@ -199,7 +201,9 @@ public class ApiToItemMapperTest {
         certifiedCopyApi.setPostageCost(POSTAGE_COST);
         certifiedCopyApi.setTotalItemCost(TOTAL_ITEM_COST);
 
-        final CertifiedCopy certifiedCopy = apiToItemMapper.apiToCertifiedCopy(certifiedCopyApi);
+        final Item item = apiToItemMapper.apiToItem(certifiedCopyApi);
+        assertThat(item instanceof CertifiedCopy, is(true));
+        final CertifiedCopy certifiedCopy = (CertifiedCopy) item;
 
         assertEquals(certifiedCopyApi.getId(), certifiedCopy.getId());
         assertThat(certifiedCopy.getId(), is(certifiedCopyApi.getId()));

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
@@ -180,6 +180,6 @@ public class CheckoutToOrderMapperTest {
         assertThat(order.getData().getOrderedBy(), is(checkout.getData().getCheckedOutBy()));
     }
 
-    // TODO GCI-1242 Implement test for certified copy mapping?
+    // TODO GCI-984 Implement test for certified copy mapping?
 
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
@@ -156,7 +156,7 @@ public class CheckoutToOrderMapperTest {
         item.setTotalItemCost(TOTAL_ITEM_COST);
         item.setKind(ITEM_KIND);
         item.setPostalDelivery(POSTAL_DELIVERY);
-        // TODO GCI-1242 Restore this item.setItemOptions(ITEM_OPTIONS);
+        item.setItemOptions(ITEM_OPTIONS);
         item.setEtag(TOKEN_ETAG);
         data.setItems(singletonList(item));
         checkout.setData(data);
@@ -179,5 +179,7 @@ public class CheckoutToOrderMapperTest {
         assertThat(order.getData().getReference(), is(checkout.getData().getReference()));
         assertThat(order.getData().getOrderedBy(), is(checkout.getData().getCheckedOutBy()));
     }
+
+    // TODO GCI-1242 Implement test for certified copy mapping?
 
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
@@ -156,7 +156,7 @@ public class CheckoutToOrderMapperTest {
         item.setTotalItemCost(TOTAL_ITEM_COST);
         item.setKind(ITEM_KIND);
         item.setPostalDelivery(POSTAL_DELIVERY);
-        item.setItemOptions(ITEM_OPTIONS);
+        // TODO GCI-1242 Restore this item.setItemOptions(ITEM_OPTIONS);
         item.setEtag(TOKEN_ETAG);
         data.setItems(singletonList(item));
         checkout.setData(data);

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapperTest.java
@@ -87,7 +87,7 @@ public class CheckoutToPaymentDetailsMapperTest {
         ITEM.setDescription(DESCRIPTION);
         ITEM.setDescriptionIdentifier(DESC_IDENTIFIER);
         ITEM.setDescriptionValues(DESC_VALUES);
-        ITEM.setItemOptions(ITEM_OPTIONS);
+        // TODO GCI-1242 Restore this ITEM.setItemOptions(ITEM_OPTIONS);
         ITEM.setEtag(ITEM_ETAG);
         ITEM.setKind(ITEM_KIND);
         ITEM.setQuantity(ITEM_QUANTITY);

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapperTest.java
@@ -87,7 +87,7 @@ public class CheckoutToPaymentDetailsMapperTest {
         ITEM.setDescription(DESCRIPTION);
         ITEM.setDescriptionIdentifier(DESC_IDENTIFIER);
         ITEM.setDescriptionValues(DESC_VALUES);
-        // TODO GCI-1242 Restore this ITEM.setItemOptions(ITEM_OPTIONS);
+        ITEM.setItemOptions(ITEM_OPTIONS);
         ITEM.setEtag(ITEM_ETAG);
         ITEM.setKind(ITEM_KIND);
         ITEM.setQuantity(ITEM_QUANTITY);
@@ -147,6 +147,8 @@ public class CheckoutToPaymentDetailsMapperTest {
         testLinks(source, target);
         testItems(source, target);
     }
+
+    // TODO GCI-1242 Implement test for certified copy mapping?
 
     private void testItems(Checkout source, PaymentDetailsDTO target){
         assertEquals(target.getItems().size(), source.getData().getItems().get(0).getItemCosts().size());

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapperTest.java
@@ -148,7 +148,7 @@ public class CheckoutToPaymentDetailsMapperTest {
         testItems(source, target);
     }
 
-    // TODO GCI-1242 Implement test for certified copy mapping?
+    // TODO GCI-984 Implement test for certified copy mapping?
 
     private void testItems(Checkout source, PaymentDetailsDTO target){
         assertEquals(target.getItems().size(), source.getData().getItems().get(0).getItemCosts().size());

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.orders.api.service;
 
 import org.junit.ClassRule;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,12 +11,14 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.companieshouse.orders.api.client.Api;
 import uk.gov.companieshouse.orders.api.mapper.ApiToItemMapper;
 import uk.gov.companieshouse.orders.api.model.*;
 
-import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.VALID_CERTIFICATE_URI;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.VALID_CERTIFIED_COPY_URI;
 
@@ -25,6 +28,9 @@ import static uk.gov.companieshouse.orders.api.util.TestConstants.VALID_CERTIFIE
 @SpringBootTest
 @SpringJUnitConfig(ApiClientServiceIntegrationTest.Config.class)
 public class ApiClientServiceIntegrationTest {
+
+    private static final String UNKNOWN_CERTIFICATE_URI = "/orderable/certificates/CRT-000000-000000";
+    public static final String UNKNOWN_CERTIFIED_COPY_URI = "/orderable/certified-copies/CCD-000000-000000";
 
     @Configuration
     @ComponentScan(basePackageClasses = {ApiClientServiceIntegrationTest.class, ApiToItemMapper.class, Api.class})
@@ -77,6 +83,40 @@ public class ApiClientServiceIntegrationTest {
         // Then
         assertThat(item instanceof CertifiedCopy, is(true));
         assertThat(item.getItemOptions() instanceof CertifiedCopyItemOptions, is(true));
+    }
+
+    @Test
+    @DisplayName("getItem() throws a 400 Bad Request response exception for unknown certificate")
+    void throwsBadRequestExceptionForCertificateNotFound () {
+
+        // Given
+        ENVIRONMENT_VARIABLES.set("CHS_API_KEY", "MGQ1MGNlYmFkYzkxZTM2MzlkNGVmMzg4ZjgxMmEz");
+        ENVIRONMENT_VARIABLES.set("API_URL", "http://api.chs-dev.internal:4001"); // TODO GCI-1022 WireMock
+        ENVIRONMENT_VARIABLES.set("PAYMENTS_API_URL", "http://api.chs-dev.internal:4001"); // TODO GCI-1022 WireMock
+
+        // When and then
+        final ResponseStatusException exception =
+                Assertions.assertThrows(ResponseStatusException.class,
+                        () -> serviceUnderTest.getItem(UNKNOWN_CERTIFICATE_URI));
+        assertThat(exception.getStatus(), is(BAD_REQUEST));
+        // TODO GCI-1022 assertThat(exception.getReason(), is("Error getting company name for company number 00006400"));
+    }
+
+    @Test
+    @DisplayName("getItem() throws a 400 Bad Request response exception for unknown certified copy")
+    void throwsBadRequestExceptionForCertifiedCopyNotFound () {
+
+        // Given
+        ENVIRONMENT_VARIABLES.set("CHS_API_KEY", "MGQ1MGNlYmFkYzkxZTM2MzlkNGVmMzg4ZjgxMmEz");
+        ENVIRONMENT_VARIABLES.set("API_URL", "http://api.chs-dev.internal:4001"); // TODO GCI-1022 WireMock
+        ENVIRONMENT_VARIABLES.set("PAYMENTS_API_URL", "http://api.chs-dev.internal:4001"); // TODO GCI-1022 WireMock
+
+        // When and then
+        final ResponseStatusException exception =
+                Assertions.assertThrows(ResponseStatusException.class,
+                        () -> serviceUnderTest.getItem(UNKNOWN_CERTIFIED_COPY_URI));
+        assertThat(exception.getStatus(), is(BAD_REQUEST));
+        // TODO GCI-1022 assertThat(exception.getReason(), is("Error getting company name for company number 00006400"));
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceIntegrationTest.java
@@ -1,0 +1,82 @@
+package uk.gov.companieshouse.orders.api.service;
+
+import org.junit.ClassRule;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import uk.gov.companieshouse.orders.api.client.Api;
+import uk.gov.companieshouse.orders.api.mapper.ApiToItemMapper;
+import uk.gov.companieshouse.orders.api.model.*;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.VALID_CERTIFICATE_URI;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.VALID_CERTIFIED_COPY_URI;
+
+/**
+ * Partially integration tests the {@link ApiClientService} service.
+ */
+@SpringBootTest
+@SpringJUnitConfig(ApiClientServiceIntegrationTest.Config.class)
+public class ApiClientServiceIntegrationTest {
+
+    @Configuration
+    @ComponentScan(basePackageClasses = {ApiClientServiceIntegrationTest.class, ApiToItemMapper.class, Api.class})
+    static class Config { }
+
+    @Autowired
+    private ApiClientService serviceUnderTest;
+
+    @MockBean
+    private BasketService basketService;
+
+    @MockBean
+    private CheckoutService checkoutService;
+
+    @MockBean
+    private OrderService orderService;
+
+    @ClassRule
+    public static final EnvironmentVariables ENVIRONMENT_VARIABLES = new EnvironmentVariables();
+
+    @Test
+    @DisplayName("getItem() gets a certificate correctly")
+    void getsCertificateCorrectly() throws Exception {
+
+        // Given
+        ENVIRONMENT_VARIABLES.set("CHS_API_KEY", "MGQ1MGNlYmFkYzkxZTM2MzlkNGVmMzg4ZjgxMmEz");
+        ENVIRONMENT_VARIABLES.set("API_URL", "http://api.chs-dev.internal:4001"); // TODO GCI-1022 WireMock
+        ENVIRONMENT_VARIABLES.set("PAYMENTS_API_URL", "http://api.chs-dev.internal:4001"); // TODO GCI-1022 WireMock
+
+        // When
+        final Item item = serviceUnderTest.getItem(VALID_CERTIFICATE_URI);
+
+        // Then
+        assertThat(item instanceof Certificate, is(true));
+        assertThat(item.getItemOptions() instanceof CertificateItemOptions, is(true));
+    }
+
+    @Test
+    @DisplayName("getItem() gets a certified copy correctly")
+    void getsCertifiedCopyCorrectly() throws Exception {
+
+        // Given
+        ENVIRONMENT_VARIABLES.set("CHS_API_KEY", "MGQ1MGNlYmFkYzkxZTM2MzlkNGVmMzg4ZjgxMmEz");
+        ENVIRONMENT_VARIABLES.set("API_URL", "http://api.chs-dev.internal:4001"); // TODO GCI-1022 WireMock
+        ENVIRONMENT_VARIABLES.set("PAYMENTS_API_URL", "http://api.chs-dev.internal:4001"); // TODO GCI-1022 WireMock
+
+        // When
+        final Item item = serviceUnderTest.getItem(VALID_CERTIFIED_COPY_URI);
+
+        // Then
+        assertThat(item instanceof CertifiedCopy, is(true));
+        assertThat(item.getItemOptions() instanceof CertifiedCopyItemOptions, is(true));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceIntegrationTest.java
@@ -87,7 +87,7 @@ public class ApiClientServiceIntegrationTest {
 
     @Test
     @DisplayName("getItem() gets a certificate correctly")
-    void getsCertificateCorrectly() throws Exception {
+    void getItemGetsCertificateCorrectly() throws Exception {
 
         // Given
         givenSdkIsConfigured(environment, ENVIRONMENT_VARIABLES);
@@ -106,7 +106,7 @@ public class ApiClientServiceIntegrationTest {
 
     @Test
     @DisplayName("getItem() gets a certified copy correctly")
-    void getsCertifiedCopyCorrectly() throws Exception {
+    void getItemGetsCertifiedCopyCorrectly() throws Exception {
 
         // Given
         givenSdkIsConfigured(environment, ENVIRONMENT_VARIABLES);
@@ -125,14 +125,14 @@ public class ApiClientServiceIntegrationTest {
 
     @Test
     @DisplayName("getItem() incorrectly throws an IllegalArgumentException for unknown certificate")
-    void throwsIllegalArgumentExceptionForCertificateNotFound () {
+    void getItemThrowsIllegalArgumentExceptionForCertificateNotFound () {
         throwsIllegalArgumentExceptionForItemNotFound(UNKNOWN_CERTIFICATE_URI,
                                                       CERTIFICATES_API_NOT_FOUND_ERROR_RESPONSE_BODY);
     }
 
     @Test
     @DisplayName("getItem() incorrectly throws an IllegalArgumentException for unknown certified copy")
-    void throwsIllegalArgumentExceptionForCertifiedCopyNotFound () {
+    void getItemThrowsIllegalArgumentExceptionForCertifiedCopyNotFound () {
         throwsIllegalArgumentExceptionForItemNotFound(UNKNOWN_CERTIFIED_COPY_URI,
                 CERTIFIED_COPIES_API_NOT_FOUND_ERROR_RESPONSE_BODY);
     }

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
@@ -71,23 +71,24 @@ public class ApiClientServiceTest {
     @Mock
     private ApiResponse<CertificateApi> certificateApiResponse;
 
-    @Test
-    public void shouldGetCertificateItemIfUriIsValid() throws Exception {
-        when(api.getInternalApiClient()).thenReturn(mockInternalApiClient);
-        when(mockInternalApiClient.privateItemResourceHandler()).thenReturn(privateItemResourceHandler);
-        when(privateItemResourceHandler.getCertificate(VALID_CERTIFICATE_URI)).thenReturn(certificateGet);
-        when(certificateGet.execute()).thenReturn(certificateApiResponse);
-
-        Certificate certificate = new Certificate();
-        certificate.setCompanyNumber(COMPANY_NUMBER);
-        when(apiToCertificateMapper.apiToCertificate(certificateApiResponse.getData())).thenReturn(certificate);
-
-        Item item = serviceUnderTest.getItem(VALID_CERTIFICATE_URI);
-
-        assertEquals(COMPANY_NUMBER, item.getCompanyNumber());
-        assertEquals(VALID_CERTIFICATE_URI, item.getItemUri());
-        assertEquals(ItemStatus.UNKNOWN, item.getStatus());
-    }
+    // TODO GCI-1242 Restore this test
+//    @Test
+//    public void shouldGetCertificateItemIfUriIsValid() throws Exception {
+//        when(api.getInternalApiClient()).thenReturn(mockInternalApiClient);
+//        when(mockInternalApiClient.privateItemResourceHandler()).thenReturn(privateItemResourceHandler);
+//        when(privateItemResourceHandler.getCertificate(VALID_CERTIFICATE_URI)).thenReturn(certificateGet);
+//        when(certificateGet.execute()).thenReturn(certificateApiResponse);
+//
+//        Certificate certificate = new Certificate();
+//        certificate.setCompanyNumber(COMPANY_NUMBER);
+//        when(apiToCertificateMapper.apiToCertificate(certificateApiResponse.getData())).thenReturn(certificate);
+//
+//        Item item = serviceUnderTest.getItem(VALID_CERTIFICATE_URI);
+//
+//        assertEquals(COMPANY_NUMBER, item.getCompanyNumber());
+//        assertEquals(VALID_CERTIFICATE_URI, item.getItemUri());
+//        assertEquals(ItemStatus.UNKNOWN, item.getStatus());
+//    }
 
     @Test
     public void shouldThrowExceptionIfCertificateItemUriIsInvalid() throws ServiceException {

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
@@ -15,6 +15,7 @@ import uk.gov.companieshouse.api.handler.order.item.request.CertificateGet;
 import uk.gov.companieshouse.api.handler.payment.PaymentResourceHandler;
 import uk.gov.companieshouse.api.handler.payment.request.PaymentGet;
 import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
 import uk.gov.companieshouse.api.model.order.item.CertificateApi;
 import uk.gov.companieshouse.api.model.payment.PaymentApi;
 import uk.gov.companieshouse.orders.api.client.Api;
@@ -28,6 +29,7 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -71,24 +73,25 @@ public class ApiClientServiceTest {
     @Mock
     private ApiResponse<CertificateApi> certificateApiResponse;
 
-    // TODO GCI-1242 Restore this test
-//    @Test
-//    public void shouldGetCertificateItemIfUriIsValid() throws Exception {
-//        when(api.getInternalApiClient()).thenReturn(mockInternalApiClient);
-//        when(mockInternalApiClient.privateItemResourceHandler()).thenReturn(privateItemResourceHandler);
-//        when(privateItemResourceHandler.getCertificate(VALID_CERTIFICATE_URI)).thenReturn(certificateGet);
-//        when(certificateGet.execute()).thenReturn(certificateApiResponse);
-//
-//        Certificate certificate = new Certificate();
-//        certificate.setCompanyNumber(COMPANY_NUMBER);
-//        when(apiToCertificateMapper.apiToCertificate(certificateApiResponse.getData())).thenReturn(certificate);
-//
-//        Item item = serviceUnderTest.getItem(VALID_CERTIFICATE_URI);
-//
-//        assertEquals(COMPANY_NUMBER, item.getCompanyNumber());
-//        assertEquals(VALID_CERTIFICATE_URI, item.getItemUri());
-//        assertEquals(ItemStatus.UNKNOWN, item.getStatus());
-//    }
+    @Test
+    public void shouldGetCertificateItemIfUriIsValid() throws Exception {
+        when(api.getInternalApiClient()).thenReturn(mockInternalApiClient);
+        when(mockInternalApiClient.privateItemResourceHandler()).thenReturn(privateItemResourceHandler);
+        when(privateItemResourceHandler.getCertificate(VALID_CERTIFICATE_URI)).thenReturn(certificateGet);
+        doReturn(certificateApiResponse).when(certificateGet).execute();
+
+        Certificate certificate = new Certificate();
+        certificate.setCompanyNumber(COMPANY_NUMBER);
+        when(apiToCertificateMapper.apiToCertificate(certificateApiResponse.getData())).thenReturn(certificate);
+
+        Item item = serviceUnderTest.getItem(VALID_CERTIFICATE_URI);
+
+        assertEquals(COMPANY_NUMBER, item.getCompanyNumber());
+        assertEquals(VALID_CERTIFICATE_URI, item.getItemUri());
+        assertEquals(ItemStatus.UNKNOWN, item.getStatus());
+    }
+
+    // TODO GCI-1242 Implement tests for certified copies?
 
     @Test
     public void shouldThrowExceptionIfCertificateItemUriIsInvalid() throws ServiceException {

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
@@ -20,7 +20,7 @@ import uk.gov.companieshouse.api.model.order.item.CertifiedCopyApi;
 import uk.gov.companieshouse.api.model.payment.PaymentApi;
 import uk.gov.companieshouse.orders.api.client.Api;
 import uk.gov.companieshouse.orders.api.exception.ServiceException;
-import uk.gov.companieshouse.orders.api.mapper.ApiToCertificateMapper;
+import uk.gov.companieshouse.orders.api.mapper.ApiToItemMapper;
 import uk.gov.companieshouse.orders.api.model.*;
 
 import java.io.IOException;
@@ -51,7 +51,7 @@ public class ApiClientServiceTest {
     private ApiClientService serviceUnderTest;
 
     @Mock
-    private ApiToCertificateMapper apiToCertificateMapper;
+    private ApiToItemMapper apiToItemMapper;
 
     @Mock
     private InternalApiClient mockInternalApiClient;
@@ -89,7 +89,7 @@ public class ApiClientServiceTest {
 
         Certificate certificate = new Certificate();
         certificate.setCompanyNumber(COMPANY_NUMBER);
-        when(apiToCertificateMapper.apiToCertificate(certificateApiResponse.getData())).thenReturn(certificate);
+        when(apiToItemMapper.apiToCertificate(certificateApiResponse.getData())).thenReturn(certificate);
 
         Item item = serviceUnderTest.getItem(VALID_CERTIFICATE_URI);
 
@@ -110,7 +110,7 @@ public class ApiClientServiceTest {
         final CertificateItemOptions options = new CertificateItemOptions();
         options.setCertificateType(INCORPORATION_WITH_ALL_NAME_CHANGES);
         certificate.setItemOptions(options);
-        when(apiToCertificateMapper.apiToCertificate(certificateApiResponse.getData())).thenReturn(certificate);
+        when(apiToItemMapper.apiToCertificate(certificateApiResponse.getData())).thenReturn(certificate);
 
         // When
         final Item item = serviceUnderTest.getItem(VALID_CERTIFICATE_URI);
@@ -133,7 +133,7 @@ public class ApiClientServiceTest {
         final CertifiedCopyItemOptions options = new CertifiedCopyItemOptions();
         options.setFilingHistoryDocuments(singletonList(DOCUMENT));
         copy.setItemOptions(options);
-        when(apiToCertificateMapper.apiToCertifiedCopy(certifiedCopyApiResponse.getData())).thenReturn(copy);
+        when(apiToItemMapper.apiToCertifiedCopy(certifiedCopyApiResponse.getData())).thenReturn(copy);
 
         // When
         final Item item = serviceUnderTest.getItem(VALID_CERTIFIED_COPY_URI);

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
@@ -87,7 +87,7 @@ public class ApiClientServiceTest {
 
         Certificate certificate = new Certificate();
         certificate.setCompanyNumber(COMPANY_NUMBER);
-        when(apiToItemMapper.apiToCertificate(certificateApiResponse.getData())).thenReturn(certificate);
+        when(apiToItemMapper.apiToItem(certificateApiResponse.getData())).thenReturn(certificate);
 
         Item item = serviceUnderTest.getItem(VALID_CERTIFICATE_URI);
 
@@ -108,7 +108,7 @@ public class ApiClientServiceTest {
         final CertificateItemOptions options = new CertificateItemOptions();
         options.setCertificateType(INCORPORATION_WITH_ALL_NAME_CHANGES);
         certificate.setItemOptions(options);
-        when(apiToItemMapper.apiToCertificate(certificateApiResponse.getData())).thenReturn(certificate);
+        when(apiToItemMapper.apiToItem(certificateApiResponse.getData())).thenReturn(certificate);
 
         // When
         final Item item = serviceUnderTest.getItem(VALID_CERTIFICATE_URI);
@@ -131,7 +131,7 @@ public class ApiClientServiceTest {
         final CertifiedCopyItemOptions options = new CertifiedCopyItemOptions();
         options.setFilingHistoryDocuments(singletonList(DOCUMENT));
         copy.setItemOptions(options);
-        when(apiToItemMapper.apiToCertifiedCopy(certifiedCopyApiResponse.getData())).thenReturn(copy);
+        when(apiToItemMapper.apiToItem(certifiedCopyApiResponse.getData())).thenReturn(copy);
 
         // When
         final Item item = serviceUnderTest.getItem(VALID_CERTIFIED_COPY_URI);

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
@@ -33,15 +33,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.orders.api.model.CertificateType.INCORPORATION_WITH_ALL_NAME_CHANGES;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.DOCUMENT;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.*;
 
 @ExtendWith(MockitoExtension.class)
 public class ApiClientServiceTest {
     private static final String PAYMENT_ID = "987654321";
     private static final String AMOUNT = "500";
     private static final String DESCRIPTION = "description";
-    private static final String VALID_CERTIFICATE_URI = "/orderable/certificates/CHS00001";
-    private static final String VALID_CERTIFIED_COPY_URI = "/orderable/certified-copies/CCD-473815-935982";
     private static final String VALID_PAYMENT_URI = "/payments/" + PAYMENT_ID;
     private static final String INVALID_CERTIFICATE_URI = "/test/test/CHS00001";
     private static final String COMPANY_NUMBER = "00006400";

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
@@ -143,11 +143,18 @@ public class ApiClientServiceTest {
     }
 
     @Test
-    public void shouldThrowExceptionIfCertificateItemUriIsInvalid() throws ServiceException {
-        ServiceException exception = assertThrows(ServiceException.class, () -> {
-            Item item = serviceUnderTest.getItem(INVALID_CERTIFICATE_URI);
-        });
-        assertEquals("Unrecognised uri pattern for "+INVALID_CERTIFICATE_URI, exception.getMessage());
+    public void shouldThrowExceptionIfCertificateItemUriIsInvalid() throws Exception {
+
+        // Given
+        when(api.getInternalApiClient()).thenReturn(mockInternalApiClient);
+        when(mockInternalApiClient.privateItemResourceHandler()).thenReturn(privateItemResourceHandler);
+        when(privateItemResourceHandler.getItem(INVALID_CERTIFICATE_URI)).thenReturn(itemGet);
+        when(itemGet.execute()).thenThrow(new URIValidationException("Test exception"));
+
+        // When and then
+        ServiceException exception =
+                assertThrows(ServiceException.class, () -> serviceUnderTest.getItem(INVALID_CERTIFICATE_URI));
+        assertEquals("Unrecognised uri pattern for " + INVALID_CERTIFICATE_URI, exception.getMessage());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
@@ -11,7 +11,7 @@ import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.handler.order.item.PrivateItemResourceHandler;
-import uk.gov.companieshouse.api.handler.order.item.request.CertificateGet;
+import uk.gov.companieshouse.api.handler.order.item.request.ItemGet;
 import uk.gov.companieshouse.api.handler.payment.PaymentResourceHandler;
 import uk.gov.companieshouse.api.handler.payment.request.PaymentGet;
 import uk.gov.companieshouse.api.model.ApiResponse;
@@ -72,7 +72,7 @@ public class ApiClientServiceTest {
     private PaymentGet paymentGet;
 
     @Mock
-    private CertificateGet certificateGet;
+    private ItemGet itemGet;
 
     @Mock
     private ApiResponse<CertificateApi> certificateApiResponse;
@@ -84,8 +84,8 @@ public class ApiClientServiceTest {
     public void shouldGetCertificateItemIfUriIsValid() throws Exception {
         when(api.getInternalApiClient()).thenReturn(mockInternalApiClient);
         when(mockInternalApiClient.privateItemResourceHandler()).thenReturn(privateItemResourceHandler);
-        when(privateItemResourceHandler.getCertificate(VALID_CERTIFICATE_URI)).thenReturn(certificateGet);
-        doReturn(certificateApiResponse).when(certificateGet).execute();
+        when(privateItemResourceHandler.getCertificate(VALID_CERTIFICATE_URI)).thenReturn(itemGet);
+        doReturn(certificateApiResponse).when(itemGet).execute();
 
         Certificate certificate = new Certificate();
         certificate.setCompanyNumber(COMPANY_NUMBER);
@@ -104,8 +104,8 @@ public class ApiClientServiceTest {
         // Given
         when(api.getInternalApiClient()).thenReturn(mockInternalApiClient);
         when(mockInternalApiClient.privateItemResourceHandler()).thenReturn(privateItemResourceHandler);
-        when(privateItemResourceHandler.getCertificate(VALID_CERTIFICATE_URI)).thenReturn(certificateGet);
-        doReturn(certificateApiResponse).when(certificateGet).execute();
+        when(privateItemResourceHandler.getCertificate(VALID_CERTIFICATE_URI)).thenReturn(itemGet);
+        doReturn(certificateApiResponse).when(itemGet).execute();
         final Certificate certificate = new Certificate();
         final CertificateItemOptions options = new CertificateItemOptions();
         options.setCertificateType(INCORPORATION_WITH_ALL_NAME_CHANGES);
@@ -127,8 +127,8 @@ public class ApiClientServiceTest {
         // Given
         when(api.getInternalApiClient()).thenReturn(mockInternalApiClient);
         when(mockInternalApiClient.privateItemResourceHandler()).thenReturn(privateItemResourceHandler);
-        when(privateItemResourceHandler.getCertificate(VALID_CERTIFIED_COPY_URI)).thenReturn(certificateGet);
-        doReturn(certifiedCopyApiResponse).when(certificateGet).execute();
+        when(privateItemResourceHandler.getCertificate(VALID_CERTIFIED_COPY_URI)).thenReturn(itemGet);
+        doReturn(certifiedCopyApiResponse).when(itemGet).execute();
         final CertifiedCopy copy = new CertifiedCopy();
         final CertifiedCopyItemOptions options = new CertifiedCopyItemOptions();
         options.setFilingHistoryDocuments(singletonList(DOCUMENT));

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/ApiClientServiceTest.java
@@ -84,7 +84,7 @@ public class ApiClientServiceTest {
     public void shouldGetCertificateItemIfUriIsValid() throws Exception {
         when(api.getInternalApiClient()).thenReturn(mockInternalApiClient);
         when(mockInternalApiClient.privateItemResourceHandler()).thenReturn(privateItemResourceHandler);
-        when(privateItemResourceHandler.getCertificate(VALID_CERTIFICATE_URI)).thenReturn(itemGet);
+        when(privateItemResourceHandler.getItem(VALID_CERTIFICATE_URI)).thenReturn(itemGet);
         doReturn(certificateApiResponse).when(itemGet).execute();
 
         Certificate certificate = new Certificate();
@@ -104,7 +104,7 @@ public class ApiClientServiceTest {
         // Given
         when(api.getInternalApiClient()).thenReturn(mockInternalApiClient);
         when(mockInternalApiClient.privateItemResourceHandler()).thenReturn(privateItemResourceHandler);
-        when(privateItemResourceHandler.getCertificate(VALID_CERTIFICATE_URI)).thenReturn(itemGet);
+        when(privateItemResourceHandler.getItem(VALID_CERTIFICATE_URI)).thenReturn(itemGet);
         doReturn(certificateApiResponse).when(itemGet).execute();
         final Certificate certificate = new Certificate();
         final CertificateItemOptions options = new CertificateItemOptions();
@@ -127,7 +127,7 @@ public class ApiClientServiceTest {
         // Given
         when(api.getInternalApiClient()).thenReturn(mockInternalApiClient);
         when(mockInternalApiClient.privateItemResourceHandler()).thenReturn(privateItemResourceHandler);
-        when(privateItemResourceHandler.getCertificate(VALID_CERTIFIED_COPY_URI)).thenReturn(itemGet);
+        when(privateItemResourceHandler.getItem(VALID_CERTIFIED_COPY_URI)).thenReturn(itemGet);
         doReturn(certifiedCopyApiResponse).when(itemGet).execute();
         final CertifiedCopy copy = new CertifiedCopy();
         final CertifiedCopyItemOptions options = new CertifiedCopyItemOptions();

--- a/src/test/java/uk/gov/companieshouse/orders/api/util/TestConstants.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/util/TestConstants.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.orders.api.util;
 
+import uk.gov.companieshouse.orders.api.model.FilingHistoryDocument;
+
 public class TestConstants {
 
     /** The HTTP request ID header name. */
@@ -15,5 +17,13 @@ public class TestConstants {
     public static final String ERIC_AUTHORISED_USER_VALUE = "demo@ch.gov.uk";
     public static final String ERIC_IDENTITY_API_KEY_TYPE_VALUE = "key";
     public static final String ERIC_IDENTITY_INVALID_TYPE_VALUE = "invalid identity type";
+
+    public static final FilingHistoryDocument DOCUMENT = new FilingHistoryDocument(
+            "1993-04-01",
+            "memorandum-articles",
+            null,
+            "MDAxMTEyNzExOGFkaXF6a2N4",
+            "MEM/ARTS"
+    );
 
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/util/TestConstants.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/util/TestConstants.java
@@ -17,6 +17,8 @@ public class TestConstants {
     public static final String ERIC_AUTHORISED_USER_VALUE = "demo@ch.gov.uk";
     public static final String ERIC_IDENTITY_API_KEY_TYPE_VALUE = "key";
     public static final String ERIC_IDENTITY_INVALID_TYPE_VALUE = "invalid identity type";
+    public static final String VALID_CERTIFICATE_URI = "/orderable/certificates/CRT-283515-943657";
+    public static final String VALID_CERTIFIED_COPY_URI = "/orderable/certified-copies/CCD-473815-935982";
 
     public static final FilingHistoryDocument DOCUMENT = new FilingHistoryDocument(
             "1993-04-01",

--- a/src/test/java/uk/gov/companieshouse/orders/api/util/TestUtils.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/util/TestUtils.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.orders.api.util;
+
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.springframework.core.env.Environment;
+
+public class TestUtils {
+
+    /**
+     * Configures the CH Java SDKs used in WireMock based integration tests to interact with WireMock
+     * stubbed/mocked API endpoints.
+     * @param environment the Spring {@link Environment} the tests are run in
+     * @param variables {@link EnvironmentVariables} class rule permitting environment variable manipulation
+     * @return the WireMock port value used for the tests
+     */
+    public static String givenSdkIsConfigured(final Environment environment, final EnvironmentVariables variables) {
+        final String wireMockPort = environment.getProperty("wiremock.server.port");
+        variables.set("CHS_API_KEY", "MGQ1MGNlYmFkYzkxZTM2MzlkNGVmMzg4ZjgxMmEz");
+        variables.set("API_URL", "http://localhost:" + wireMockPort);
+        variables.set("PAYMENTS_API_URL", "http://localhost:" + wireMockPort);
+        return wireMockPort;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidatorTest.java
@@ -60,11 +60,10 @@ public class CheckoutBasketValidatorTest {
 
     @Test
     @DisplayName("getValidationErrors returns error for invalid item")
-    public void getValidationErrorsReportsInvalidItem() throws Exception {
+    public void getValidationErrorsReportsInvalidItem() {
         // Given
         Basket basket = setupBasketWithInvalidItem();
         // When
-        when(apiClientService.getItem(anyString())).thenThrow(Exception.class);
         List<String> errors = validatorUnderTest.getValidationErrors(basket);
         // Then
         assertThat(errors.isEmpty(), is(false));

--- a/src/test/postman/Orders_API.postman_collection.json
+++ b/src/test/postman/Orders_API.postman_collection.json
@@ -378,7 +378,13 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": ""
+									"raw": "{{base_url}}/basket",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"basket"
+									]
 								}
 							},
 							"response": []

--- a/src/test/postman/Orders_API.postman_collection.json
+++ b/src/test/postman/Orders_API.postman_collection.json
@@ -39,7 +39,7 @@
 					"name": "Add item to basket",
 					"item": [
 						{
-							"name": "Add item to basket",
+							"name": "Add certificate item to basket",
 							"request": {
 								"method": "POST",
 								"header": [
@@ -58,6 +58,45 @@
 								"body": {
 									"mode": "raw",
 									"raw": "{\n\t\"item_uri\": \"/orderable/certificates/CHS00000000000000001\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/basket/items",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"basket",
+										"items"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add certified copy item to basket",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Request-ID",
+										"type": "text",
+										"value": "f058ebd6-02f7-4d3f-942e-904344e8cde5"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"item_uri\": \"/orderable/certified-copies/CCD-857115-929072\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"

--- a/src/test/postman/Orders_API.postman_collection.json
+++ b/src/test/postman/Orders_API.postman_collection.json
@@ -57,7 +57,124 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"item_uri\": \"/orderable/certificates/CHS00000000000000001\"\n}",
+									"raw": "{\n\t\"item_uri\": \"/orderable/certificates/CRT-283515-943657\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/basket/items",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"basket",
+										"items"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add unknown certificate item to basket",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Request-ID",
+										"type": "text",
+										"value": "f058ebd6-02f7-4d3f-942e-904344e8cde5"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"item_uri\": \"/orderable/certificates/CRT-000000-000000\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/basket/items",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"basket",
+										"items"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add certificate item to basket with incorrect URI",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Request-ID",
+										"type": "text",
+										"value": "f058ebd6-02f7-4d3f-942e-904344e8cde5"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"item_uri\": \"/orderable/certificates/CRT-283515-943657\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/basket/items",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"basket",
+										"items"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add certificate item to basket with syntax error",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Request-ID",
+										"type": "text",
+										"value": "f058ebd6-02f7-4d3f-942e-904344e8cde5"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"item_uri\": \"/orderable/certificates/CRT-283515-943657\"x\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -96,7 +213,124 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"item_uri\": \"/orderable/certified-copies/CCD-857115-929072\"\n}",
+									"raw": "{\n\t\"item_uri\": \"/orderable/certified-copies/CCD-473815-935982\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/basket/items",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"basket",
+										"items"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add unknown certified copy item to basket",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Request-ID",
+										"type": "text",
+										"value": "f058ebd6-02f7-4d3f-942e-904344e8cde5"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"item_uri\": \"/orderable/certified-copies/CCD-000000-000000\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/basket/items",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"basket",
+										"items"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add certified copy item to basket with incorrect URI",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Request-ID",
+										"type": "text",
+										"value": "f058ebd6-02f7-4d3f-942e-904344e8cde5"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"item_uri\": \"/orderable/certified_copies/CCD-473815-935982/x\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/basket/items",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"basket",
+										"items"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add certified copy item to basket with syntax error",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Request-ID",
+										"type": "text",
+										"value": "f058ebd6-02f7-4d3f-942e-904344e8cde5"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"item_uri\": \"/orderable/certified-copies/CCD-473815-935982\n}",
 									"options": {
 										"raw": {
 											"language": "json"


### PR DESCRIPTION
* Functionality broadened so that either a certificate or a certified copy item may be added to the basket, and the details of the item viewed in the response to a get basket request.