### PR TITLE
GCI-984: Allow checkout of certified copies in Orders API

### DIFF
--- a/src/main/java/uk/gov/companieshouse/orders/api/listener/MongoCheckoutListener.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/listener/MongoCheckoutListener.java
@@ -1,44 +1,23 @@
 package uk.gov.companieshouse.orders.api.listener;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.bson.Document;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterConvertEvent;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.orders.api.model.CertificateItemOptions;
-import uk.gov.companieshouse.orders.api.model.CertifiedCopyItemOptions;
 import uk.gov.companieshouse.orders.api.model.Checkout;
 import uk.gov.companieshouse.orders.api.model.Item;
-import uk.gov.companieshouse.orders.api.model.ItemOptions;
 
-import java.io.IOException;
 import java.util.List;
-
-import static java.util.Arrays.stream;
 
 @Component
 public class MongoCheckoutListener extends AbstractMongoEventListener<Checkout> {
 
-    @Autowired
-    private ObjectMapper mapper;
+    private static final String CHECKOUT_ORDER_TYPE_NAME = "checkout";
 
-    /** Values of this represent different item types (aka kinds). */
-    enum ItemType {
-        CERTIFICATE("item#certificate", CertificateItemOptions.class),
-        CERTIFIED_COPY("item#certified-copy", CertifiedCopyItemOptions.class);
+    private final OrderItemOptionsReader reader;
 
-        ItemType(final String kind, final Class<? extends ItemOptions> optionsType) {
-            this.kind = kind;
-            this.optionsType = optionsType;
-        }
-
-        Class<? extends ItemOptions> getOptionsType() {
-            return optionsType;
-        }
-
-        private String kind;
-        private Class<? extends ItemOptions> optionsType;
+    MongoCheckoutListener(final OrderItemOptionsReader reader) {
+        this.reader = reader;
     }
 
     /**
@@ -48,79 +27,9 @@ public class MongoCheckoutListener extends AbstractMongoEventListener<Checkout> 
      */
     @Override
     public void onAfterConvert(final AfterConvertEvent<Checkout> event) {
-
         final Document checkoutDocument = event.getDocument();
-        if (checkoutDocument == null) {
-            throw new IllegalStateException("No checkout document found on event.");
-        }
         final List<Item> items = event.getSource().getData().getItems();
-
-        for (int index = 0; index < items.size(); index++) {
-            try {
-                readCheckoutItemsOptions(index, items, checkoutDocument);
-            } catch (IOException ioe) {
-                throw new IllegalStateException("Error parsing item options JSON: " + ioe.getMessage());
-            }
-        }
-
-    }
-
-    /**
-     * Reads the item options for each item correctly. How to read these options correctly from the DB is determined
-     * from the kind of the item. Updates the item options assigned to each item.
-     * @param itemIndex the item index identifying both the item within the items collection and its {@link Document}
-     * @param items the items held by the checkout
-     * @param checkoutDocument the checkout {@link Document} from the DB
-     * @throws IOException should there be an issue parsing the item options JSON from the DB
-     */
-    void readCheckoutItemsOptions(final int itemIndex, final List<Item> items, final Document checkoutDocument)
-            throws IOException {
-        final Item item = items.get(itemIndex);
-        final Document optionsDocument = getItemOptionsDocument(checkoutDocument, itemIndex);
-        if (optionsDocument == null) {
-            // No item options to read.
-            return;
-        }
-        final ItemOptions options = readItemOptions(optionsDocument, item.getKind());
-        item.setItemOptions(options);
-    }
-
-    /**
-     * Gets the document representing the item's item options.
-     * @param checkoutDocument the {@link Document} representing the checkout
-     * @param itemIndex the index of the item within the collection of items held within the checkout
-     * @return the {@link Document} representing the item options for the item identified by the index
-     */
-    Document getItemOptionsDocument(final Document checkoutDocument, final int itemIndex) {
-        @SuppressWarnings("unchecked") // Java language limitation (type erasure)
-        final Document itemDocument =
-                ((List<Document>) checkoutDocument.get("data", Document.class).get("items", List.class)).get(itemIndex);
-        return itemDocument.get("item_options", Document.class);
-    }
-
-    /**
-     * Reads (deserialises) the options document into the correct type of item options object.
-     * @param optionsDocument the {@link Document} from the DB representing the item options
-     * @param kind the item kind used to determine the correct item options class for the object to read the
-     *             document into
-     * @return the deserialised item options object, either a {@link CertificateItemOptions}, or a
-     * {@link CertifiedCopyItemOptions} as appropriate for the kind
-     * @throws IOException should there be an issue parsing the item options JSON from the DB
-     */
-    ItemOptions readItemOptions(final Document optionsDocument, final String kind) throws IOException {
-        return mapper.readValue(optionsDocument.toJson(), getType(kind).optionsType);
-    }
-
-    /**
-     * Gets the {@link ItemType} corresponding to the kind presented.
-     * @param kind the kind
-     * @return the corresponding {@link ItemType}
-     */
-    ItemType getType(final String kind) {
-        return stream(ItemType.values())
-                .filter(value -> value.kind.equals(kind))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("'" + kind + "' is not a known kind!"));
+        reader.readOrderItemsOptions(items, checkoutDocument, CHECKOUT_ORDER_TYPE_NAME);
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/listener/MongoOrderListener.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/listener/MongoOrderListener.java
@@ -1,0 +1,126 @@
+package uk.gov.companieshouse.orders.api.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bson.Document;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
+import org.springframework.data.mongodb.core.mapping.event.AfterConvertEvent;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.orders.api.model.CertificateItemOptions;
+import uk.gov.companieshouse.orders.api.model.CertifiedCopyItemOptions;
+import uk.gov.companieshouse.orders.api.model.Item;
+import uk.gov.companieshouse.orders.api.model.ItemOptions;
+import uk.gov.companieshouse.orders.api.model.Order;
+
+import java.io.IOException;
+import java.util.List;
+
+import static java.util.Arrays.stream;
+
+@Component
+public class MongoOrderListener extends AbstractMongoEventListener<Order> {
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    /** Values of this represent different item types (aka kinds). */
+    enum ItemType {
+        CERTIFICATE("item#certificate", CertificateItemOptions.class),
+        CERTIFIED_COPY("item#certified-copy", CertifiedCopyItemOptions.class);
+
+        ItemType(final String kind, final Class<? extends ItemOptions> optionsType) {
+            this.kind = kind;
+            this.optionsType = optionsType;
+        }
+
+        Class<? extends ItemOptions> getOptionsType() {
+            return optionsType;
+        }
+
+        private String kind;
+        private Class<? extends ItemOptions> optionsType;
+    }
+
+    /**
+     * Overridden here to intervene in the reading of a {@link Order} from the database to make sure the
+     * item options, if present, are read correctly.
+     * @param event the {@link AfterConvertEvent} presenting both the mapped {@link Order} and its {@link Document}
+     */
+    @Override
+    public void onAfterConvert(final AfterConvertEvent<Order> event) {
+
+        final Document orderDocument = event.getDocument();
+        if (orderDocument == null) {
+            throw new IllegalStateException("No order document found on event.");
+        }
+        final List<Item> items = event.getSource().getData().getItems();
+
+        for (int index = 0; index < items.size(); index++) {
+            try {
+                readOrderItemsOptions(index, items, orderDocument);
+            } catch (IOException ioe) {
+                throw new IllegalStateException("Error parsing item options JSON: " + ioe.getMessage());
+            }
+        }
+
+    }
+
+    /**
+     * Reads the item options for each item correctly. How to read these options correctly from the DB is determined
+     * from the kind of the item. Updates the item options assigned to each item.
+     * @param itemIndex the item index identifying both the item within the items collection and its {@link Document}
+     * @param items the items held by the order
+     * @param orderDocument the order {@link Document} from the DB
+     * @throws IOException should there be an issue parsing the item options JSON from the DB
+     */
+    void readOrderItemsOptions(final int itemIndex, final List<Item> items, final Document orderDocument)
+            throws IOException {
+        final Item item = items.get(itemIndex);
+        final Document optionsDocument = getItemOptionsDocument(orderDocument, itemIndex);
+        if (optionsDocument == null) {
+            // No item options to read.
+            return;
+        }
+        final ItemOptions options = readItemOptions(optionsDocument, item.getKind());
+        item.setItemOptions(options);
+    }
+
+    /**
+     * Gets the document representing the item's item options.
+     * @param orderDocument the {@link Document} representing the order
+     * @param itemIndex the index of the item within the collection of items held within the order
+     * @return the {@link Document} representing the item options for the item identified by the index
+     */
+    Document getItemOptionsDocument(final Document orderDocument, final int itemIndex) {
+        @SuppressWarnings("unchecked") // Java language limitation (type erasure)
+        final Document itemDocument =
+                ((List<Document>) orderDocument.get("data", Document.class).get("items", List.class)).get(itemIndex);
+        return itemDocument.get("item_options", Document.class);
+    }
+
+    /**
+     * Reads (deserialises) the options document into the correct type of item options object.
+     * @param optionsDocument the {@link Document} from the DB representing the item options
+     * @param kind the item kind used to determine the correct item options class for the object to read the
+     *             document into
+     * @return the deserialised item options object, either a {@link CertificateItemOptions}, or a
+     * {@link CertifiedCopyItemOptions} as appropriate for the kind
+     * @throws IOException should there be an issue parsing the item options JSON from the DB
+     */
+    ItemOptions readItemOptions(final Document optionsDocument, final String kind) throws IOException {
+        return mapper.readValue(optionsDocument.toJson(), getType(kind).optionsType);
+    }
+
+    /**
+     * Gets the {@link ItemType} corresponding to the kind presented.
+     * @param kind the kind
+     * @return the corresponding {@link ItemType}
+     */
+    ItemType getType(final String kind) {
+        return stream(ItemType.values())
+                .filter(value -> value.kind.equals(kind))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("'" + kind + "' is not a known kind!"));
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/orders/api/listener/MongoOrderListener.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/listener/MongoOrderListener.java
@@ -1,126 +1,35 @@
 package uk.gov.companieshouse.orders.api.listener;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.bson.Document;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterConvertEvent;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.orders.api.model.CertificateItemOptions;
-import uk.gov.companieshouse.orders.api.model.CertifiedCopyItemOptions;
 import uk.gov.companieshouse.orders.api.model.Item;
-import uk.gov.companieshouse.orders.api.model.ItemOptions;
 import uk.gov.companieshouse.orders.api.model.Order;
 
-import java.io.IOException;
 import java.util.List;
-
-import static java.util.Arrays.stream;
 
 @Component
 public class MongoOrderListener extends AbstractMongoEventListener<Order> {
 
-    @Autowired
-    private ObjectMapper mapper;
+    private static final String ORDER_ORDER_TYPE_NAME = "order";
 
-    /** Values of this represent different item types (aka kinds). */
-    enum ItemType {
-        CERTIFICATE("item#certificate", CertificateItemOptions.class),
-        CERTIFIED_COPY("item#certified-copy", CertifiedCopyItemOptions.class);
+    private final OrderItemOptionsReader reader;
 
-        ItemType(final String kind, final Class<? extends ItemOptions> optionsType) {
-            this.kind = kind;
-            this.optionsType = optionsType;
-        }
-
-        Class<? extends ItemOptions> getOptionsType() {
-            return optionsType;
-        }
-
-        private String kind;
-        private Class<? extends ItemOptions> optionsType;
+    public MongoOrderListener(final OrderItemOptionsReader reader) {
+        this.reader = reader;
     }
 
     /**
-     * Overridden here to intervene in the reading of a {@link Order} from the database to make sure the
+     * Overridden here to intervene in the reading of an {@link Order} from the database to make sure the
      * item options, if present, are read correctly.
      * @param event the {@link AfterConvertEvent} presenting both the mapped {@link Order} and its {@link Document}
      */
     @Override
     public void onAfterConvert(final AfterConvertEvent<Order> event) {
-
         final Document orderDocument = event.getDocument();
-        if (orderDocument == null) {
-            throw new IllegalStateException("No order document found on event.");
-        }
         final List<Item> items = event.getSource().getData().getItems();
-
-        for (int index = 0; index < items.size(); index++) {
-            try {
-                readOrderItemsOptions(index, items, orderDocument);
-            } catch (IOException ioe) {
-                throw new IllegalStateException("Error parsing item options JSON: " + ioe.getMessage());
-            }
-        }
-
-    }
-
-    /**
-     * Reads the item options for each item correctly. How to read these options correctly from the DB is determined
-     * from the kind of the item. Updates the item options assigned to each item.
-     * @param itemIndex the item index identifying both the item within the items collection and its {@link Document}
-     * @param items the items held by the order
-     * @param orderDocument the order {@link Document} from the DB
-     * @throws IOException should there be an issue parsing the item options JSON from the DB
-     */
-    void readOrderItemsOptions(final int itemIndex, final List<Item> items, final Document orderDocument)
-            throws IOException {
-        final Item item = items.get(itemIndex);
-        final Document optionsDocument = getItemOptionsDocument(orderDocument, itemIndex);
-        if (optionsDocument == null) {
-            // No item options to read.
-            return;
-        }
-        final ItemOptions options = readItemOptions(optionsDocument, item.getKind());
-        item.setItemOptions(options);
-    }
-
-    /**
-     * Gets the document representing the item's item options.
-     * @param orderDocument the {@link Document} representing the order
-     * @param itemIndex the index of the item within the collection of items held within the order
-     * @return the {@link Document} representing the item options for the item identified by the index
-     */
-    Document getItemOptionsDocument(final Document orderDocument, final int itemIndex) {
-        @SuppressWarnings("unchecked") // Java language limitation (type erasure)
-        final Document itemDocument =
-                ((List<Document>) orderDocument.get("data", Document.class).get("items", List.class)).get(itemIndex);
-        return itemDocument.get("item_options", Document.class);
-    }
-
-    /**
-     * Reads (deserialises) the options document into the correct type of item options object.
-     * @param optionsDocument the {@link Document} from the DB representing the item options
-     * @param kind the item kind used to determine the correct item options class for the object to read the
-     *             document into
-     * @return the deserialised item options object, either a {@link CertificateItemOptions}, or a
-     * {@link CertifiedCopyItemOptions} as appropriate for the kind
-     * @throws IOException should there be an issue parsing the item options JSON from the DB
-     */
-    ItemOptions readItemOptions(final Document optionsDocument, final String kind) throws IOException {
-        return mapper.readValue(optionsDocument.toJson(), getType(kind).optionsType);
-    }
-
-    /**
-     * Gets the {@link ItemType} corresponding to the kind presented.
-     * @param kind the kind
-     * @return the corresponding {@link ItemType}
-     */
-    ItemType getType(final String kind) {
-        return stream(ItemType.values())
-                .filter(value -> value.kind.equals(kind))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("'" + kind + "' is not a known kind!"));
+        reader.readOrderItemsOptions(items, orderDocument, ORDER_ORDER_TYPE_NAME);
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/listener/OrderItemOptionsReader.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/listener/OrderItemOptionsReader.java
@@ -1,0 +1,125 @@
+package uk.gov.companieshouse.orders.api.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bson.Document;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.orders.api.model.CertificateItemOptions;
+import uk.gov.companieshouse.orders.api.model.CertifiedCopyItemOptions;
+import uk.gov.companieshouse.orders.api.model.Item;
+import uk.gov.companieshouse.orders.api.model.ItemOptions;
+
+import java.io.IOException;
+import java.util.List;
+
+import static java.util.Arrays.stream;
+
+/**
+ * Reads (deserialises) the item options for each item on an order read from the DB.
+ */
+@Component
+class OrderItemOptionsReader {
+
+    private final ObjectMapper mapper;
+
+    OrderItemOptionsReader(final ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    /** Values of this represent different item types (aka kinds). */
+    enum ItemType {
+        CERTIFICATE("item#certificate", CertificateItemOptions.class),
+        CERTIFIED_COPY("item#certified-copy", CertifiedCopyItemOptions.class);
+
+        ItemType(final String kind, final Class<? extends ItemOptions> optionsType) {
+            this.kind = kind;
+            this.optionsType = optionsType;
+        }
+
+        Class<? extends ItemOptions> getOptionsType() {
+            return optionsType;
+        }
+
+        private String kind;
+        private Class<? extends ItemOptions> optionsType;
+    }
+
+    /**
+     * Reads the item options for each item on the order in the DB as represented by the order document.
+     * @param items {@link List List&lt;Item&gt;} of the items read from the order
+     * @param orderDocument the order document representing either a
+     * {@link uk.gov.companieshouse.orders.api.model.Checkout} or an
+     * {@link uk.gov.companieshouse.orders.api.model.Order}
+     * @param orderType a human-readable name for the type of order, i.e., "checkout" or "order"
+     */
+    void readOrderItemsOptions(final List<Item> items, final Document orderDocument, final String orderType) {
+        if (orderDocument == null) {
+            throw new IllegalStateException("No " + orderType + " document found on event.");
+        }
+        for (int itemIndex = 0; itemIndex < items.size(); itemIndex++) {
+            try {
+                readItemOptions(itemIndex, items, orderDocument);
+            } catch (IOException ioe) {
+                throw new IllegalStateException("Error parsing item options JSON: " + ioe.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Reads the item options for the item indicated by the index. How to read these options correctly from the DB
+     * is determined from the kind of the item. Updates the item options assigned to the item.
+     * @param itemIndex the item index identifying both the item within the items collection and its {@link Document}
+     * @param items the items held by the order
+     * @param orderDocument the order {@link Document} from the DB
+     * @throws IOException should there be an issue parsing the item options JSON from the DB
+     */
+    void readItemOptions(final int itemIndex, final List<Item> items, final Document orderDocument)
+            throws IOException {
+        final Item item = items.get(itemIndex);
+        final Document optionsDocument = getItemOptionsDocument(orderDocument, itemIndex);
+        if (optionsDocument == null) {
+            // No item options to read.
+            return;
+        }
+        final ItemOptions options = readItemOptions(optionsDocument, item.getKind());
+        item.setItemOptions(options);
+    }
+
+    /**
+     * Gets the document representing the item's item options.
+     * @param orderDocument the {@link Document} representing the order
+     * @param itemIndex the index of the item within the collection of items held within the order
+     * @return the {@link Document} representing the item options for the item identified by the index
+     */
+    Document getItemOptionsDocument(final Document orderDocument, final int itemIndex) {
+        @SuppressWarnings("unchecked") // Java language limitation (type erasure)
+        final Document itemDocument =
+                ((List<Document>) orderDocument.get("data", Document.class).get("items", List.class)).get(itemIndex);
+        return itemDocument.get("item_options", Document.class);
+    }
+
+    /**
+     * Reads (deserialises) the options document into the correct type of item options object.
+     * @param optionsDocument the {@link Document} from the DB representing the item options
+     * @param kind the item kind used to determine the correct item options class for the object to read the
+     *             document into
+     * @return the deserialised item options object, either a {@link CertificateItemOptions}, or a
+     * {@link CertifiedCopyItemOptions} as appropriate for the kind
+     * @throws IOException should there be an issue parsing the item options JSON from the DB
+     */
+    ItemOptions readItemOptions(final Document optionsDocument, final String kind) throws IOException {
+        return mapper.readValue(optionsDocument.toJson(), getType(kind).optionsType);
+    }
+
+    /**
+     * Gets the {@link ItemType} corresponding to the kind presented.
+     * @param kind the kind
+     * @return the corresponding {@link ItemType}
+     */
+    ItemType getType(final String kind) {
+        return stream(ItemType.values())
+                .filter(value -> value.kind.equals(kind))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("'" + kind + "' is not a known kind!"));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -1084,10 +1084,9 @@ class BasketControllerIntegrationTest {
         assertThat(data.getItems(), is(notNullValue()));
         assertThat(data.getItems().isEmpty(), is(false));
         assertThat(data.getItems().get(0), is(notNullValue()));
+
         final Item checkoutItem = data.getItems().get(0);
-        assertThat(checkoutItem.getItemOptions() instanceof CertificateItemOptions, is(true));
-        final CertificateItemOptions options = (CertificateItemOptions) checkoutItem.getItemOptions();
-        assertThat(options.getCertificateType(), is(INCORPORATION_WITH_ALL_NAME_CHANGES));
+        verifyCertifiedCopyItemOptionsAreCorrect(checkoutItem);
 
         // Assert order is created with correct information
         final Order orderRetrieved = assertOrderCreatedCorrectly(checkout.getId(), timestamps);
@@ -1097,10 +1096,7 @@ class BasketControllerIntegrationTest {
         assertThat(retrievedItem.getPostageCost(), is(POSTAGE_COST));
         assertThat(retrievedItem.getTotalItemCost(), is(TOTAL_ITEM_COST));
 
-        // TODO GCI-984 Should we be expecting the following?
-//        assertThat(retrievedItem.getItemOptions() instanceof CertificateItemOptions, is(true));
-//        final CertificateItemOptions retrievedOptions = (CertificateItemOptions) checkoutItem.getItemOptions();
-//        assertThat(retrievedOptions.getCertificateType(), is(INCORPORATION_WITH_ALL_NAME_CHANGES));
+        verifyCertifiedCopyItemOptionsAreCorrect(retrievedItem);
     }
 
     @Test
@@ -1349,6 +1345,17 @@ class BasketControllerIntegrationTest {
                 .andExpect(jsonPath("$.links.resource", is(mapper.convertValue(paymentLinksDTO.getResource(), String.class))))
                 .andDo(MockMvcResultHandlers.print());
 
+    }
+
+    /**
+     * Verifies that the certified copy item's options are of the right type and have the expected field
+     * correctly populated.
+     * @param certifiedCopy the {@link Item} to check
+     */
+    private void verifyCertifiedCopyItemOptionsAreCorrect(final Item certifiedCopy) {
+        assertThat(certifiedCopy.getItemOptions() instanceof CertificateItemOptions, is(true));
+        final CertificateItemOptions options = (CertificateItemOptions) certifiedCopy.getItemOptions();
+        assertThat(options.getCertificateType(), is(INCORPORATION_WITH_ALL_NAME_CHANGES));
     }
 
     private List<ItemCosts> createItemCosts(){

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -425,6 +425,7 @@ class BasketControllerIntegrationTest {
         certificate.setCompanyNumber(COMPANY_NUMBER);
         certificate.setKind(CERTIFICATE_KIND);
         final CertificateItemOptions options = new CertificateItemOptions();
+        options.setCertificateType(INCORPORATION_WITH_ALL_NAME_CHANGES);
         options.setForename(FORENAME);
         options.setSurname(SURNAME);
         certificate.setItemOptions(options);
@@ -438,7 +439,9 @@ class BasketControllerIntegrationTest {
                 .header(ERIC_IDENTITY_TYPE_HEADER_NAME, ERIC_IDENTITY_OAUTH2_TYPE_VALUE)
                 .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
                 .header(ERIC_AUTHORISED_USER_HEADER_NAME, ERIC_AUTHORISED_USER_VALUE))
-                .andExpect(status().isAccepted());
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.items[0].item_options.certificate_type",
+                        is(INCORPORATION_WITH_ALL_NAME_CHANGES.getJsonName())));
 
         MvcResult result = resultActions.andReturn();
         MockHttpServletResponse response = result.getResponse();

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -459,6 +459,7 @@ class BasketControllerIntegrationTest {
         assertEquals(FORENAME, retrievedOptions.getForename());
         assertEquals(SURNAME, retrievedOptions.getSurname());
         assertEquals(EXPECTED_TOTAL_ORDER_COST, checkoutData.getTotalOrderCost());
+        verifyCertificateItemOptionsAreCorrect(retrievedCheckout.get().getData().getItems().get(0));
     }
 
     private Basket getBasket(boolean isPostalDelivery) {
@@ -1360,6 +1361,7 @@ class BasketControllerIntegrationTest {
         final CertificateItemOptions options = (CertificateItemOptions) certificate.getItemOptions();
         assertThat(options.getCertificateType(), is(INCORPORATION_WITH_ALL_NAME_CHANGES));
     }
+
 
     private List<ItemCosts> createItemCosts(){
         List<ItemCosts> itemCosts = new ArrayList<>();

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -1089,7 +1089,7 @@ class BasketControllerIntegrationTest {
         assertThat(data.getItems().get(0), is(notNullValue()));
 
         final Item checkoutItem = data.getItems().get(0);
-        verifyCertifiedCopyItemOptionsAreCorrect(checkoutItem);
+        verifyCertificateItemOptionsAreCorrect(checkoutItem);
 
         // Assert order is created with correct information
         final Order orderRetrieved = assertOrderCreatedCorrectly(checkout.getId(), timestamps);
@@ -1099,7 +1099,7 @@ class BasketControllerIntegrationTest {
         assertThat(retrievedItem.getPostageCost(), is(POSTAGE_COST));
         assertThat(retrievedItem.getTotalItemCost(), is(TOTAL_ITEM_COST));
 
-        verifyCertifiedCopyItemOptionsAreCorrect(retrievedItem);
+        verifyCertificateItemOptionsAreCorrect(retrievedItem);
     }
 
     @Test
@@ -1351,13 +1351,13 @@ class BasketControllerIntegrationTest {
     }
 
     /**
-     * Verifies that the certified copy item's options are of the right type and have the expected field
+     * Verifies that the certificate item's options are of the right type and have the expected field
      * correctly populated.
-     * @param certifiedCopy the {@link Item} to check
+     * @param certificate the {@link Item} to check
      */
-    private void verifyCertifiedCopyItemOptionsAreCorrect(final Item certifiedCopy) {
-        assertThat(certifiedCopy.getItemOptions() instanceof CertificateItemOptions, is(true));
-        final CertificateItemOptions options = (CertificateItemOptions) certifiedCopy.getItemOptions();
+    private void verifyCertificateItemOptionsAreCorrect(final Item certificate) {
+        assertThat(certificate.getItemOptions() instanceof CertificateItemOptions, is(true));
+        final CertificateItemOptions options = (CertificateItemOptions) certificate.getItemOptions();
         assertThat(options.getCertificateType(), is(INCORPORATION_WITH_ALL_NAME_CHANGES));
     }
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -1560,31 +1560,33 @@ class BasketControllerIntegrationTest {
     }
 
     private Checkout createCertifiedCopyCheckout() {
-        final Item item = new Item();
-        item.setItemCosts(ITEM_COSTS);
-        item.setPostageCost(POSTAGE_COST);
-        item.setTotalItemCost(TOTAL_ITEM_COST);
-        item.setCompanyNumber(COMPANY_NUMBER);
-        item.setKind(CERTIFIED_COPY_KIND);
+        final CertifiedCopy copy = new CertifiedCopy();
+        copy.setItemCosts(ITEM_COSTS);
+        copy.setPostageCost(POSTAGE_COST);
+        copy.setTotalItemCost(TOTAL_ITEM_COST);
+        copy.setCompanyNumber(COMPANY_NUMBER);
+        copy.setKind(CERTIFIED_COPY_KIND);
         final CertifiedCopyItemOptions options = new CertifiedCopyItemOptions();
         options.setFilingHistoryDocuments(singletonList(DOCUMENT));
-        item.setItemOptions(options);
+        copy.setItemOptions(options);
 
-        return checkoutService.createCheckout(item, ERIC_IDENTITY_VALUE, ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
+        return checkoutService.createCheckout(
+                copy, ERIC_IDENTITY_VALUE, ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
     }
 
     private Checkout createCertificateCheckout() {
-        final Item item = new Item();
-        item.setItemCosts(ITEM_COSTS);
-        item.setPostageCost(POSTAGE_COST);
-        item.setTotalItemCost(TOTAL_ITEM_COST);
-        item.setCompanyNumber(COMPANY_NUMBER);
-        item.setKind(CERTIFICATE_KIND);
+        final Certificate certificate = new Certificate();
+        certificate.setItemCosts(ITEM_COSTS);
+        certificate.setPostageCost(POSTAGE_COST);
+        certificate.setTotalItemCost(TOTAL_ITEM_COST);
+        certificate.setCompanyNumber(COMPANY_NUMBER);
+        certificate.setKind(CERTIFICATE_KIND);
         final CertificateItemOptions options = new CertificateItemOptions();
         options.setCertificateType(INCORPORATION_WITH_ALL_NAME_CHANGES);
-        item.setItemOptions(options);
+        certificate.setItemOptions(options);
 
-        return checkoutService.createCheckout(item, ERIC_IDENTITY_VALUE, ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
+        return checkoutService.createCheckout(
+                certificate, ERIC_IDENTITY_VALUE, ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -421,7 +421,7 @@ class BasketControllerIntegrationTest {
     @Test
     @DisplayName("Checkout basket successfully creates checkout, when basket contains a valid certificate uri")
     void checkoutBasketSuccessfullyCreatesCheckoutWhenBasketIsValid() throws Exception {
-        basketRepository.save(getBasket(false));
+        basketRepository.save(getBasketWithCertificateInIt(false));
 
         Certificate certificate = new Certificate();
         certificate.setCompanyNumber(COMPANY_NUMBER);
@@ -463,7 +463,7 @@ class BasketControllerIntegrationTest {
     @Test
     @DisplayName("Checkout basket responds with correctly populated certificate item options")
     void checkoutCertificateBasketReturnsCorrectlyPopulatedOptions() throws Exception {
-        basketRepository.save(getBasket(false));
+        basketRepository.save(getBasketWithCertificateInIt(false));
 
         final Certificate certificate = new Certificate();
         certificate.setKind(CERTIFICATE_KIND);
@@ -497,7 +497,7 @@ class BasketControllerIntegrationTest {
     @Test
     @DisplayName("Checkout basket responds with correctly populated certified copy item options")
     void checkoutCertifiedCopyBasketReturnsCorrectlyPopulatedOptions() throws Exception {
-        basketRepository.save(getBasket(false, VALID_CERTIFIED_COPY_URI));
+        basketRepository.save(getBasketWithCertifiedCopyInIt());
 
         final CertifiedCopy copy = new CertifiedCopy();
         copy.setKind(CERTIFIED_COPY_KIND);
@@ -534,8 +534,12 @@ class BasketControllerIntegrationTest {
         verifyCertifiedCopyItemOptionsAreCorrect(retrievedCheckout.get().getData().getItems().get(0));
     }
 
-    private Basket getBasket(boolean isPostalDelivery) {
+    private Basket getBasketWithCertificateInIt(boolean isPostalDelivery) {
         return getBasket(isPostalDelivery, VALID_CERTIFICATE_URI);
+    }
+
+    private Basket getBasketWithCertifiedCopyInIt() {
+        return getBasket(false, VALID_CERTIFIED_COPY_URI);
     }
 
     private Basket getBasket(boolean isPostalDelivery, final String itemUri) {
@@ -565,7 +569,7 @@ class BasketControllerIntegrationTest {
     @Test
     @DisplayName("Checkout basket returns 200 when total order cost is zero")
     void checkoutBasketReturns200WhenTotalOrderCostIsZero() throws Exception {
-        basketRepository.save(getBasket(false));
+        basketRepository.save(getBasketWithCertificateInIt(false));
 
         Certificate certificate = new Certificate();
         certificate.setKind(CERTIFICATE_KIND);
@@ -601,7 +605,7 @@ class BasketControllerIntegrationTest {
     @Test
     @DisplayName("Checkout basket returns 202 when total order cost is non-zero")
     void checkoutBasketReturns202WhenTotalOrderCostIsNonZero() throws Exception {
-        basketRepository.save(getBasket(true));
+        basketRepository.save(getBasketWithCertificateInIt(true));
 
         final Certificate certificate = new Certificate();
         certificate.setKind(CERTIFICATE_KIND);
@@ -664,7 +668,7 @@ class BasketControllerIntegrationTest {
     @Test
     @DisplayName("Checkout Basket fails to create checkout and returns 400, when there is a failure getting the item")
     void checkoutBasketFailsToCreateCheckoutWhenItFailsToGetAnItem() throws Exception {
-        basketRepository.save(getBasket(false));
+        basketRepository.save(getBasketWithCertificateInIt(false));
 
         when(apiClientService.getItem(VALID_CERTIFICATE_URI)).thenThrow(apiErrorResponseException);
 
@@ -695,7 +699,7 @@ class BasketControllerIntegrationTest {
     @Test
     @DisplayName("Checkout basket successfully creates checkout with costs from Certificates API")
     void checkoutBasketCheckoutContainsCosts() throws Exception {
-        basketRepository.save(getBasket(false));
+        basketRepository.save(getBasketWithCertificateInIt(false));
 
         final Certificate certificate = new Certificate();
         certificate.setKind(CERTIFICATE_KIND);
@@ -1129,7 +1133,7 @@ class BasketControllerIntegrationTest {
 
         BasketPaymentRequestDTO basketPaymentRequest = createBasketPaymentRequest(PaymentStatus.PAID);
         createBasket(start);
-        Checkout checkout = createCheckout();
+        Checkout checkout = createCertificateCheckout();
         PaymentApi paymentSession = createPaymentSession(checkout.getId(), "paid", "70.00");
 
         when(apiClientService.getPaymentSummary(ERIC_ACCESS_TOKEN, PAYMENT_ID)).thenReturn(paymentSession);
@@ -1176,7 +1180,7 @@ class BasketControllerIntegrationTest {
 
         final BasketPaymentRequestDTO basketPaymentRequest = createBasketPaymentRequest(PaymentStatus.PAID);
         createBasket(start);
-        final Checkout checkout = createCheckout();
+        final Checkout checkout = createCertificateCheckout();
         final PaymentApi paymentSession = createPaymentSession(checkout.getId(), "paid", "70.00");
 
         when(apiClientService.getPaymentSummary(ERIC_ACCESS_TOKEN, PAYMENT_ID)).thenReturn(paymentSession);
@@ -1260,7 +1264,7 @@ class BasketControllerIntegrationTest {
 
         BasketPaymentRequestDTO basketPaymentRequest = createBasketPaymentRequest(PaymentStatus.FAILED);
         createBasket(start);
-        Checkout checkout = createCheckout();
+        Checkout checkout = createCertificateCheckout();
 
         mockMvc.perform(patch("/basket/checkouts/" + checkout.getId() + "/payment")
                 .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
@@ -1284,7 +1288,7 @@ class BasketControllerIntegrationTest {
 
         BasketPaymentRequestDTO basketPaymentRequest = createBasketPaymentRequest(PaymentStatus.CANCELLED);
         createBasket(start);
-        Checkout checkout = createCheckout();
+        Checkout checkout = createCertificateCheckout();
 
         mockMvc.perform(patch("/basket/checkouts/" + checkout.getId() + "/payment")
                 .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
@@ -1308,7 +1312,7 @@ class BasketControllerIntegrationTest {
 
         BasketPaymentRequestDTO basketPaymentRequest = createBasketPaymentRequest(PaymentStatus.NO_FUNDS);
         createBasket(start);
-        Checkout checkout = createCheckout();
+        Checkout checkout = createCertificateCheckout();
 
         mockMvc.perform(patch("/basket/checkouts/" + checkout.getId() + "/payment")
                 .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
@@ -1332,7 +1336,7 @@ class BasketControllerIntegrationTest {
 
         BasketPaymentRequestDTO basketPaymentRequest = createBasketPaymentRequest(PaymentStatus.PAID);
         createBasket(start);
-        Checkout checkout = createCheckout();
+        Checkout checkout = createCertificateCheckout();
 
         when(apiClientService.getPaymentSummary(ERIC_ACCESS_TOKEN, PAYMENT_ID)).thenThrow(new IOException());
 
@@ -1358,7 +1362,7 @@ class BasketControllerIntegrationTest {
 
         BasketPaymentRequestDTO basketPaymentRequest = createBasketPaymentRequest(PaymentStatus.PAID);
         createBasket(start);
-        Checkout checkout = createCheckout();
+        Checkout checkout = createCertificateCheckout();
         PaymentApi paymentSession = createPaymentSession(checkout.getId(), "pending", "70.00");
 
         when(apiClientService.getPaymentSummary(ERIC_ACCESS_TOKEN, PAYMENT_ID)).thenReturn(paymentSession);
@@ -1385,7 +1389,7 @@ class BasketControllerIntegrationTest {
 
         BasketPaymentRequestDTO basketPaymentRequest = createBasketPaymentRequest(PaymentStatus.PAID);
         createBasket(start);
-        Checkout checkout = createCheckout();
+        Checkout checkout = createCertificateCheckout();
         PaymentApi paymentSession = createPaymentSession(checkout.getId(), "paid", "70.50");
 
         when(apiClientService.getPaymentSummary(ERIC_ACCESS_TOKEN, PAYMENT_ID)).thenReturn(paymentSession);
@@ -1412,7 +1416,7 @@ class BasketControllerIntegrationTest {
 
         BasketPaymentRequestDTO basketPaymentRequest = createBasketPaymentRequest(PaymentStatus.PAID);
         createBasket(start);
-        Checkout checkout = createCheckout();
+        Checkout checkout = createCertificateCheckout();
         PaymentApi paymentSession = createPaymentSession("invalid", "paid", "70.00");
 
         when(apiClientService.getPaymentSummary(ERIC_ACCESS_TOKEN, PAYMENT_ID)).thenReturn(paymentSession);
@@ -1449,7 +1453,7 @@ class BasketControllerIntegrationTest {
     @DisplayName("Get payment details endpoint successfully gets payment details")
     void getPaymentDetailsSuccessfully() throws Exception {
         // When item(s) checked out
-        final Checkout checkout = createCheckout();
+        final Checkout checkout = createCertificateCheckout();
 
         final PaymentDetailsDTO paymentDetailsDTO = createPaymentDetailsDTO(PaymentStatus.PENDING);
         final PaymentLinksDTO paymentLinksDTO = createPaymentLinksDTO(checkout.getId());
@@ -1476,7 +1480,7 @@ class BasketControllerIntegrationTest {
     void getsPaidPaymentDetailsSuccessfully() throws Exception {
 
         // Given item(s) checked out and paid for
-        final Checkout checkout = createCheckout();
+        final Checkout checkout = createCertificateCheckout();
         payForOrder(checkout);
 
         final PaymentDetailsDTO paymentDetailsDTO = createPaymentDetailsDTO(PaymentStatus.PAID);
@@ -1569,7 +1573,7 @@ class BasketControllerIntegrationTest {
         return checkoutService.createCheckout(item, ERIC_IDENTITY_VALUE, ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
     }
 
-    private Checkout createCheckout() {
+    private Checkout createCertificateCheckout() {
         final Item item = new Item();
         item.setItemCosts(ITEM_COSTS);
         item.setPostageCost(POSTAGE_COST);

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/OrderControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/OrderControllerIntegrationTest.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.orders.api.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -10,15 +11,31 @@ import org.springframework.http.MediaType;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.companieshouse.orders.api.model.Certificate;
+import uk.gov.companieshouse.orders.api.model.CertificateItemOptions;
+import uk.gov.companieshouse.orders.api.model.CertifiedCopy;
+import uk.gov.companieshouse.orders.api.model.CertifiedCopyItemOptions;
 import uk.gov.companieshouse.orders.api.model.Order;
 import uk.gov.companieshouse.orders.api.model.OrderData;
 import uk.gov.companieshouse.orders.api.repository.OrderRepository;
 
+import static java.util.Collections.singletonList;
+import static org.hamcrest.core.Is.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.*;
+import static uk.gov.companieshouse.orders.api.model.CertificateType.INCORPORATION_WITH_ALL_NAME_CHANGES;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.CERTIFICATE_KIND;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.CERTIFIED_COPY_KIND;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.DOCUMENT;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_HEADER_NAME;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_OAUTH2_TYPE_VALUE;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_TYPE_HEADER_NAME;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_VALUE;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.REQUEST_ID_HEADER_NAME;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.TOKEN_REQUEST_ID_VALUE;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.WRONG_ERIC_IDENTITY_VALUE;
 
 @DirtiesContext
 @AutoConfigureMockMvc
@@ -60,6 +77,64 @@ class OrderControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().json(mapper.writeValueAsString(orderData)));
+    }
+
+    @Test
+    @DisplayName("Get order responds with correctly populated certificate item options")
+    void getOrderCertificateItemOptionsCorrectly() throws Exception {
+        final Order preexistingOrder = new Order();
+        preexistingOrder.setId(ORDER_ID);
+        preexistingOrder.setUserId(ERIC_IDENTITY_VALUE);
+        final OrderData orderData = new OrderData();
+        final Certificate certificate = new Certificate();
+        certificate.setKind(CERTIFICATE_KIND);
+        final CertificateItemOptions options = new CertificateItemOptions();
+        options.setCertificateType(INCORPORATION_WITH_ALL_NAME_CHANGES);
+        certificate.setItemOptions(options);
+        orderData.setItems(singletonList(certificate));
+        preexistingOrder.setData(orderData);
+        orderRepository.save(preexistingOrder);
+
+        mockMvc.perform(get("/orders/" + ORDER_ID)
+                .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
+                .header(ERIC_IDENTITY_TYPE_HEADER_NAME, ERIC_IDENTITY_OAUTH2_TYPE_VALUE)
+                .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].item_options.certificate_type",
+                        is(INCORPORATION_WITH_ALL_NAME_CHANGES.getJsonName())));
+    }
+
+    @Test
+    @DisplayName("Get order responds with correctly populated certified copy item options")
+    void getOrderCertifiedCopyItemOptionsCorrectly() throws Exception {
+        final Order preexistingOrder = new Order();
+        preexistingOrder.setId(ORDER_ID);
+        preexistingOrder.setUserId(ERIC_IDENTITY_VALUE);
+        final OrderData orderData = new OrderData();
+        final CertifiedCopy copy = new CertifiedCopy();
+        copy.setKind(CERTIFIED_COPY_KIND);
+        final CertifiedCopyItemOptions options = new CertifiedCopyItemOptions();
+        options.setFilingHistoryDocuments(singletonList(DOCUMENT));
+        copy.setItemOptions(options);
+        orderData.setItems(singletonList(copy));
+        preexistingOrder.setData(orderData);
+        orderRepository.save(preexistingOrder);
+
+        mockMvc.perform(get("/orders/" + ORDER_ID)
+                .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
+                .header(ERIC_IDENTITY_TYPE_HEADER_NAME, ERIC_IDENTITY_OAUTH2_TYPE_VALUE)
+                .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].item_options.filing_history_documents[0].filing_history_date",
+                        is(DOCUMENT.getFilingHistoryDate())))
+                .andExpect(jsonPath("$.items[0].item_options.filing_history_documents[0].filing_history_description",
+                        is(DOCUMENT.getFilingHistoryDescription())))
+                .andExpect(jsonPath("$.items[0].item_options.filing_history_documents[0].filing_history_id",
+                        is(DOCUMENT.getFilingHistoryId())))
+                .andExpect(jsonPath("$.items[0].item_options.filing_history_documents[0].filing_history_type",
+                        is(DOCUMENT.getFilingHistoryType())));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/OrderControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/OrderControllerIntegrationTest.java
@@ -24,7 +24,7 @@ import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_
 @AutoConfigureMockMvc
 @SpringBootTest
 @EmbeddedKafka
-public class OrderControllerIntegrationTest {
+class OrderControllerIntegrationTest {
     private static final String ORDER_ID = "0001";
     private static final String ORDER_REFERENCE = "0001";
 
@@ -43,7 +43,7 @@ public class OrderControllerIntegrationTest {
     }
 
     @Test
-    public void getOrderSuccessfully() throws Exception {
+    void getOrderSuccessfully() throws Exception {
         final Order preexistingOrder = new Order();
         preexistingOrder.setId(ORDER_ID);
         preexistingOrder.setUserId(ERIC_IDENTITY_VALUE);
@@ -63,7 +63,7 @@ public class OrderControllerIntegrationTest {
     }
 
     @Test
-    public void respondsWithNotFoundIfOrderDoesNotExist() throws Exception {
+   void respondsWithNotFoundIfOrderDoesNotExist() throws Exception {
         mockMvc.perform(get("/orders/"+ORDER_ID)
                 .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
                 .header(ERIC_IDENTITY_TYPE_HEADER_NAME, ERIC_IDENTITY_OAUTH2_TYPE_VALUE)
@@ -73,7 +73,7 @@ public class OrderControllerIntegrationTest {
     }
 
     @Test
-    public void getOrderUnauthorisedIfUserDoesNotOwnOrder() throws Exception {
+    void getOrderUnauthorisedIfUserDoesNotOwnOrder() throws Exception {
         final Order preexistingOrder = new Order();
         preexistingOrder.setId(ORDER_ID);
         preexistingOrder.setUserId(ERIC_IDENTITY_VALUE);

--- a/src/test/java/uk/gov/companieshouse/orders/api/listener/MongoCheckoutListenerTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/listener/MongoCheckoutListenerTest.java
@@ -1,43 +1,31 @@
 package uk.gov.companieshouse.orders.api.listener;
 
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.bson.Document;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.mongodb.core.mapping.event.AfterConvertEvent;
-import uk.gov.companieshouse.orders.api.model.CertificateItemOptions;
-import uk.gov.companieshouse.orders.api.model.CertifiedCopyItemOptions;
 import uk.gov.companieshouse.orders.api.model.Checkout;
 import uk.gov.companieshouse.orders.api.model.CheckoutData;
 import uk.gov.companieshouse.orders.api.model.Item;
 
-import java.io.IOException;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.CERTIFICATE_KIND;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.CERTIFIED_COPY_KIND;
 
 /**
  * Unit tests the {@link MongoCheckoutListener} class.
  */
 @ExtendWith(MockitoExtension.class)
 class MongoCheckoutListenerTest {
-
-    private static final String UNKNOWN_KIND = "item#unknown";
 
     @InjectMocks
     private MongoCheckoutListener listenerUnderTest;
@@ -58,138 +46,60 @@ class MongoCheckoutListenerTest {
     private List<Item> items;
 
     @Mock
-    private Item certificateItem;
+    private OrderItemOptionsReader reader;
 
-    @Mock
-    private Document checkoutDataDocument;
-
-    @Mock
-    private List<Document> itemDocuments;
-
-    @Mock
-    private Document itemDocument;
-
-    @Mock
-    private ObjectMapper mapper;
-
-    @Mock
-    private Document optionsDocument;
-
-    @Mock
-    private CertificateItemOptions certificateItemOptions;
 
     @Test
-    @DisplayName("onAfterConvert() updates item options correctly")
-    void onAfterConvertUpdatesCertificateItemOptionsCorrectly() throws IOException {
+    @DisplayName("onAfterConvert() delegates to reader")
+    void onAfterConvertDelegatesToReader() {
 
         // Given
-        when(event.getDocument()).thenReturn(checkoutDocument);
-        when(event.getSource()).thenReturn(checkout);
-        when(checkout.getData()).thenReturn(checkoutData);
-        when(checkoutData.getItems()).thenReturn(items);
-        when(items.size()).thenReturn(1);
-        when(items.get(0)).thenReturn(certificateItem);
-
-        when(checkoutDocument.get("data", Document.class)).thenReturn(checkoutDataDocument);
-        when(checkoutDataDocument.get("items", List.class)).thenReturn(itemDocuments);
-        when(itemDocuments.get(0)).thenReturn(itemDocument);
-        when(itemDocument.get("item_options", Document.class)).thenReturn(optionsDocument);
-        when(optionsDocument.toJson()).thenReturn("{}");
-        when(certificateItem.getKind()).thenReturn(CERTIFICATE_KIND);
-        when(mapper.readValue("{}", CertificateItemOptions.class)).thenReturn(certificateItemOptions);
+        givenValidEvent();
 
         // When
         listenerUnderTest.onAfterConvert(event);
 
         // Then
-        verify(items).get(0);
-        verify(certificateItem).getKind();
-        verify(mapper).readValue("{}", CertificateItemOptions.class);
-        verify(certificateItem).setItemOptions(certificateItemOptions);
-
+        verify(reader).readOrderItemsOptions(items, checkoutDocument, "checkout");
     }
 
     @Test
-    @DisplayName("onAfterConvert() copes with missing item options")
-    void onAfterConvertCopesWithMissingItemOptions() throws IOException {
+    @DisplayName("onAfterConvert() propagates reader IllegalStateException")
+    void onAfterConvertPropagatesReaderIllegalStateException() {
 
         // Given
-        when(event.getDocument()).thenReturn(checkoutDocument);
-        when(event.getSource()).thenReturn(checkout);
-        when(checkout.getData()).thenReturn(checkoutData);
-        when(checkoutData.getItems()).thenReturn(items);
-        when(items.size()).thenReturn(1);
-        when(items.get(0)).thenReturn(certificateItem);
-
-        when(checkoutDocument.get("data", Document.class)).thenReturn(checkoutDataDocument);
-        when(checkoutDataDocument.get("items", List.class)).thenReturn(itemDocuments);
-        when(itemDocuments.get(0)).thenReturn(itemDocument);
-        when(itemDocument.get("item_options", Document.class)).thenReturn(null);
-
-        // When
-        listenerUnderTest.onAfterConvert(event);
-
-        // Then
-        verify(items).get(0);
-        verify(mapper, never()).readValue(anyString(), ArgumentMatchers.eq(CertificateItemOptions.class));
-    }
-
-    @Test
-    @DisplayName("onAfterConvert() propagates mapper IOException as an IllegalStateException")
-    void onAfterConvertPropagatesMapperIOExceptionAsIllegalStateException() throws IOException {
-
-        // Given
-        when(event.getDocument()).thenReturn(checkoutDocument);
-        when(event.getSource()).thenReturn(checkout);
-        when(checkout.getData()).thenReturn(checkoutData);
-        when(checkoutData.getItems()).thenReturn(items);
-        when(items.size()).thenReturn(1);
-        when(items.get(0)).thenReturn(certificateItem);
-
-        when(checkoutDocument.get("data", Document.class)).thenReturn(checkoutDataDocument);
-        when(checkoutDataDocument.get("items", List.class)).thenReturn(itemDocuments);
-        when(itemDocuments.get(0)).thenReturn(itemDocument);
-        when(itemDocument.get("item_options", Document.class)).thenReturn(optionsDocument);
-        when(optionsDocument.toJson()).thenReturn("{}");
-        when(certificateItem.getKind()).thenReturn(CERTIFICATE_KIND);
-        when(mapper.readValue("{}", CertificateItemOptions.class)).thenThrow(new IOException("Test message"));
+        givenValidEvent();
+        doThrow(new IllegalStateException("Test exception"))
+                .when(reader).readOrderItemsOptions(items, checkoutDocument, "checkout");
 
         // When and then
         final IllegalStateException exception =
                 assertThrows(IllegalStateException.class, () -> listenerUnderTest.onAfterConvert(event));
-        assertThat(exception.getMessage(), is("Error parsing item options JSON: Test message"));
-
-        // Then
-        verify(items).get(0);
-        verify(certificateItem).getKind();
-        verify(mapper).readValue("{}", CertificateItemOptions.class);
-        verify(certificateItem, never()).setItemOptions(certificateItemOptions);
-
-    }
-
-    // TODO GCI-984 Test certified copy item options too
-
-    @Test
-    @DisplayName("onAfterConvert() throws IllegalStateException if no checkout document found on event")
-    void onAfterConvertThrowsIllegalStateExceptionIfNoCheckoutDocumentFoundOnEvent() {
-        final IllegalStateException exception =
-                assertThrows(IllegalStateException.class, () -> listenerUnderTest.onAfterConvert(event));
-        assertThat(exception.getMessage(), is("No checkout document found on event."));
+        assertThat(exception.getMessage(), is("Test exception"));
     }
 
     @Test
-    @DisplayName("getType() infers item options class type correctly from kind")
-    void getTypeInfersItemOptionsClassCorrectlyFromKind() {
-        assertEquals(CertificateItemOptions.class, listenerUnderTest.getType(CERTIFICATE_KIND).getOptionsType());
-        assertEquals(CertifiedCopyItemOptions.class, listenerUnderTest.getType(CERTIFIED_COPY_KIND).getOptionsType());
-    }
+    @DisplayName("onAfterConvert() propagates reader IllegalArgumentException")
+    void onAfterConvertPropagatesReaderIllegalArgumentException() {
+        // Given
+        givenValidEvent();
+        doThrow(new IllegalArgumentException("Test exception"))
+                .when(reader).readOrderItemsOptions(items, checkoutDocument, "checkout");
 
-    @Test
-    @DisplayName("getType() throws IllegalArgumentException for unknown kind")
-    void getTypeThrowsIllegalArgumentExceptionForUnknownKind() {
+        // When and then
         final IllegalArgumentException exception =
-                assertThrows(IllegalArgumentException.class, () -> listenerUnderTest.getType(UNKNOWN_KIND));
-        assertEquals("'" + UNKNOWN_KIND + "' is not a known kind!", exception.getMessage());
+                assertThrows(IllegalArgumentException.class, () -> listenerUnderTest.onAfterConvert(event));
+        assertThat(exception.getMessage(), is("Test exception"));
+    }
+
+    /**
+     * Provides a valid event set up for testing {@link MongoCheckoutListener#onAfterConvert(AfterConvertEvent)}.
+     */
+    private void givenValidEvent() {
+        when(event.getDocument()).thenReturn(checkoutDocument);
+        when(event.getSource()).thenReturn(checkout);
+        when(checkout.getData()).thenReturn(checkoutData);
+        when(checkoutData.getItems()).thenReturn(items);
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/listener/MongoOrderListenerTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/listener/MongoOrderListenerTest.java
@@ -1,43 +1,32 @@
 package uk.gov.companieshouse.orders.api.listener;
 
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.bson.Document;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.mongodb.core.mapping.event.AfterConvertEvent;
-import uk.gov.companieshouse.orders.api.model.CertificateItemOptions;
-import uk.gov.companieshouse.orders.api.model.CertifiedCopyItemOptions;
 import uk.gov.companieshouse.orders.api.model.Item;
 import uk.gov.companieshouse.orders.api.model.Order;
 import uk.gov.companieshouse.orders.api.model.OrderData;
 
-import java.io.IOException;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.CERTIFICATE_KIND;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.CERTIFIED_COPY_KIND;
 
 /**
  * Unit tests the {@link MongoOrderListener} class.
  */
 @ExtendWith(MockitoExtension.class)
 class MongoOrderListenerTest {
-
-    private static final String UNKNOWN_KIND = "item#unknown";
 
     @InjectMocks
     private MongoOrderListener listenerUnderTest;
@@ -58,138 +47,59 @@ class MongoOrderListenerTest {
     private List<Item> items;
 
     @Mock
-    private Item certificateItem;
+    private OrderItemOptionsReader reader;
 
-    @Mock
-    private Document orderDataDocument;
-
-    @Mock
-    private List<Document> itemDocuments;
-
-    @Mock
-    private Document itemDocument;
-
-    @Mock
-    private ObjectMapper mapper;
-
-    @Mock
-    private Document optionsDocument;
-
-    @Mock
-    private CertificateItemOptions certificateItemOptions;
 
     @Test
-    @DisplayName("onAfterConvert() updates item options correctly")
-    void onAfterConvertUpdatesCertificateItemOptionsCorrectly() throws IOException {
+    @DisplayName("onAfterConvert() delegates to reader")
+    void onAfterConvertDelegatesToReader() {
 
         // Given
-        when(event.getDocument()).thenReturn(orderDocument);
-        when(event.getSource()).thenReturn(order);
-        when(order.getData()).thenReturn(orderData);
-        when(orderData.getItems()).thenReturn(items);
-        when(items.size()).thenReturn(1);
-        when(items.get(0)).thenReturn(certificateItem);
-
-        when(orderDocument.get("data", Document.class)).thenReturn(orderDataDocument);
-        when(orderDataDocument.get("items", List.class)).thenReturn(itemDocuments);
-        when(itemDocuments.get(0)).thenReturn(itemDocument);
-        when(itemDocument.get("item_options", Document.class)).thenReturn(optionsDocument);
-        when(optionsDocument.toJson()).thenReturn("{}");
-        when(certificateItem.getKind()).thenReturn(CERTIFICATE_KIND);
-        when(mapper.readValue("{}", CertificateItemOptions.class)).thenReturn(certificateItemOptions);
+        givenValidEvent();
 
         // When
         listenerUnderTest.onAfterConvert(event);
 
         // Then
-        verify(items).get(0);
-        verify(certificateItem).getKind();
-        verify(mapper).readValue("{}", CertificateItemOptions.class);
-        verify(certificateItem).setItemOptions(certificateItemOptions);
-
+        verify(reader).readOrderItemsOptions(items, orderDocument, "order");
     }
 
     @Test
-    @DisplayName("onAfterConvert() copes with missing item options")
-    void onAfterConvertCopesWithMissingItemOptions() throws IOException {
+    @DisplayName("onAfterConvert() propagates reader IllegalStateException")
+    void onAfterConvertPropagatesReaderIllegalStateException() {
 
         // Given
-        when(event.getDocument()).thenReturn(orderDocument);
-        when(event.getSource()).thenReturn(order);
-        when(order.getData()).thenReturn(orderData);
-        when(orderData.getItems()).thenReturn(items);
-        when(items.size()).thenReturn(1);
-        when(items.get(0)).thenReturn(certificateItem);
-
-        when(orderDocument.get("data", Document.class)).thenReturn(orderDataDocument);
-        when(orderDataDocument.get("items", List.class)).thenReturn(itemDocuments);
-        when(itemDocuments.get(0)).thenReturn(itemDocument);
-        when(itemDocument.get("item_options", Document.class)).thenReturn(null);
-
-        // When
-        listenerUnderTest.onAfterConvert(event);
-
-        // Then
-        verify(items).get(0);
-        verify(mapper, never()).readValue(anyString(), ArgumentMatchers.eq(CertificateItemOptions.class));
-    }
-
-    @Test
-    @DisplayName("onAfterConvert() propagates mapper IOException as an IllegalStateException")
-    void onAfterConvertPropagatesMapperIOExceptionAsIllegalStateException() throws IOException {
-
-        // Given
-        when(event.getDocument()).thenReturn(orderDocument);
-        when(event.getSource()).thenReturn(order);
-        when(order.getData()).thenReturn(orderData);
-        when(orderData.getItems()).thenReturn(items);
-        when(items.size()).thenReturn(1);
-        when(items.get(0)).thenReturn(certificateItem);
-
-        when(orderDocument.get("data", Document.class)).thenReturn(orderDataDocument);
-        when(orderDataDocument.get("items", List.class)).thenReturn(itemDocuments);
-        when(itemDocuments.get(0)).thenReturn(itemDocument);
-        when(itemDocument.get("item_options", Document.class)).thenReturn(optionsDocument);
-        when(optionsDocument.toJson()).thenReturn("{}");
-        when(certificateItem.getKind()).thenReturn(CERTIFICATE_KIND);
-        when(mapper.readValue("{}", CertificateItemOptions.class)).thenThrow(new IOException("Test message"));
+        givenValidEvent();
+        doThrow(new IllegalStateException("Test exception"))
+                .when(reader).readOrderItemsOptions(items, orderDocument, "order");
 
         // When and then
         final IllegalStateException exception =
                 assertThrows(IllegalStateException.class, () -> listenerUnderTest.onAfterConvert(event));
-        assertThat(exception.getMessage(), is("Error parsing item options JSON: Test message"));
-
-        // Then
-        verify(items).get(0);
-        verify(certificateItem).getKind();
-        verify(mapper).readValue("{}", CertificateItemOptions.class);
-        verify(certificateItem, never()).setItemOptions(certificateItemOptions);
-
-    }
-
-    // TODO GCI-984 Test certified copy item options too
-
-    @Test
-    @DisplayName("onAfterConvert() throws IllegalStateException if no order document found on event")
-    void onAfterConvertThrowsIllegalStateExceptionIfNoOrderDocumentFoundOnEvent() {
-        final IllegalStateException exception =
-                assertThrows(IllegalStateException.class, () -> listenerUnderTest.onAfterConvert(event));
-        assertThat(exception.getMessage(), is("No order document found on event."));
+        assertThat(exception.getMessage(), is("Test exception"));
     }
 
     @Test
-    @DisplayName("getType() infers item options class type correctly from kind")
-    void getTypeInfersItemOptionsClassCorrectlyFromKind() {
-        assertEquals(CertificateItemOptions.class, listenerUnderTest.getType(CERTIFICATE_KIND).getOptionsType());
-        assertEquals(CertifiedCopyItemOptions.class, listenerUnderTest.getType(CERTIFIED_COPY_KIND).getOptionsType());
-    }
+    @DisplayName("onAfterConvert() propagates reader IllegalArgumentException")
+    void onAfterConvertPropagatesReaderIllegalArgumentException() {
+        // Given
+        givenValidEvent();
+        doThrow(new IllegalArgumentException("Test exception"))
+                .when(reader).readOrderItemsOptions(items, orderDocument, "order");
 
-    @Test
-    @DisplayName("getType() throws IllegalArgumentException for unknown kind")
-    void getTypeThrowsIllegalArgumentExceptionForUnknownKind() {
+        // When and then
         final IllegalArgumentException exception =
-                assertThrows(IllegalArgumentException.class, () -> listenerUnderTest.getType(UNKNOWN_KIND));
-        assertEquals("'" + UNKNOWN_KIND + "' is not a known kind!", exception.getMessage());
+                assertThrows(IllegalArgumentException.class, () -> listenerUnderTest.onAfterConvert(event));
+        assertThat(exception.getMessage(), is("Test exception"));
     }
 
+    /**
+     * Provides a valid event set up for testing {@link MongoOrderListener#onAfterConvert(AfterConvertEvent)}.
+     */
+    private void givenValidEvent() {
+        when(event.getDocument()).thenReturn(orderDocument);
+        when(event.getSource()).thenReturn(order);
+        when(order.getData()).thenReturn(orderData);
+        when(orderData.getItems()).thenReturn(items);
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/listener/MongoOrderListenerTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/listener/MongoOrderListenerTest.java
@@ -1,0 +1,195 @@
+package uk.gov.companieshouse.orders.api.listener;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bson.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.mapping.event.AfterConvertEvent;
+import uk.gov.companieshouse.orders.api.model.CertificateItemOptions;
+import uk.gov.companieshouse.orders.api.model.CertifiedCopyItemOptions;
+import uk.gov.companieshouse.orders.api.model.Item;
+import uk.gov.companieshouse.orders.api.model.Order;
+import uk.gov.companieshouse.orders.api.model.OrderData;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.CERTIFICATE_KIND;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.CERTIFIED_COPY_KIND;
+
+/**
+ * Unit tests the {@link MongoOrderListener} class.
+ */
+@ExtendWith(MockitoExtension.class)
+class MongoOrderListenerTest {
+
+    private static final String UNKNOWN_KIND = "item#unknown";
+
+    @InjectMocks
+    private MongoOrderListener listenerUnderTest;
+
+    @Mock
+    private AfterConvertEvent<Order> event;
+
+    @Mock
+    private Document orderDocument;
+
+    @Mock
+    private Order order;
+
+    @Mock
+    private OrderData orderData;
+
+    @Mock
+    private List<Item> items;
+
+    @Mock
+    private Item certificateItem;
+
+    @Mock
+    private Document orderDataDocument;
+
+    @Mock
+    private List<Document> itemDocuments;
+
+    @Mock
+    private Document itemDocument;
+
+    @Mock
+    private ObjectMapper mapper;
+
+    @Mock
+    private Document optionsDocument;
+
+    @Mock
+    private CertificateItemOptions certificateItemOptions;
+
+    @Test
+    @DisplayName("onAfterConvert() updates item options correctly")
+    void onAfterConvertUpdatesCertificateItemOptionsCorrectly() throws IOException {
+
+        // Given
+        when(event.getDocument()).thenReturn(orderDocument);
+        when(event.getSource()).thenReturn(order);
+        when(order.getData()).thenReturn(orderData);
+        when(orderData.getItems()).thenReturn(items);
+        when(items.size()).thenReturn(1);
+        when(items.get(0)).thenReturn(certificateItem);
+
+        when(orderDocument.get("data", Document.class)).thenReturn(orderDataDocument);
+        when(orderDataDocument.get("items", List.class)).thenReturn(itemDocuments);
+        when(itemDocuments.get(0)).thenReturn(itemDocument);
+        when(itemDocument.get("item_options", Document.class)).thenReturn(optionsDocument);
+        when(optionsDocument.toJson()).thenReturn("{}");
+        when(certificateItem.getKind()).thenReturn(CERTIFICATE_KIND);
+        when(mapper.readValue("{}", CertificateItemOptions.class)).thenReturn(certificateItemOptions);
+
+        // When
+        listenerUnderTest.onAfterConvert(event);
+
+        // Then
+        verify(items).get(0);
+        verify(certificateItem).getKind();
+        verify(mapper).readValue("{}", CertificateItemOptions.class);
+        verify(certificateItem).setItemOptions(certificateItemOptions);
+
+    }
+
+    @Test
+    @DisplayName("onAfterConvert() copes with missing item options")
+    void onAfterConvertCopesWithMissingItemOptions() throws IOException {
+
+        // Given
+        when(event.getDocument()).thenReturn(orderDocument);
+        when(event.getSource()).thenReturn(order);
+        when(order.getData()).thenReturn(orderData);
+        when(orderData.getItems()).thenReturn(items);
+        when(items.size()).thenReturn(1);
+        when(items.get(0)).thenReturn(certificateItem);
+
+        when(orderDocument.get("data", Document.class)).thenReturn(orderDataDocument);
+        when(orderDataDocument.get("items", List.class)).thenReturn(itemDocuments);
+        when(itemDocuments.get(0)).thenReturn(itemDocument);
+        when(itemDocument.get("item_options", Document.class)).thenReturn(null);
+
+        // When
+        listenerUnderTest.onAfterConvert(event);
+
+        // Then
+        verify(items).get(0);
+        verify(mapper, never()).readValue(anyString(), ArgumentMatchers.eq(CertificateItemOptions.class));
+    }
+
+    @Test
+    @DisplayName("onAfterConvert() propagates mapper IOException as an IllegalStateException")
+    void onAfterConvertPropagatesMapperIOExceptionAsIllegalStateException() throws IOException {
+
+        // Given
+        when(event.getDocument()).thenReturn(orderDocument);
+        when(event.getSource()).thenReturn(order);
+        when(order.getData()).thenReturn(orderData);
+        when(orderData.getItems()).thenReturn(items);
+        when(items.size()).thenReturn(1);
+        when(items.get(0)).thenReturn(certificateItem);
+
+        when(orderDocument.get("data", Document.class)).thenReturn(orderDataDocument);
+        when(orderDataDocument.get("items", List.class)).thenReturn(itemDocuments);
+        when(itemDocuments.get(0)).thenReturn(itemDocument);
+        when(itemDocument.get("item_options", Document.class)).thenReturn(optionsDocument);
+        when(optionsDocument.toJson()).thenReturn("{}");
+        when(certificateItem.getKind()).thenReturn(CERTIFICATE_KIND);
+        when(mapper.readValue("{}", CertificateItemOptions.class)).thenThrow(new IOException("Test message"));
+
+        // When and then
+        final IllegalStateException exception =
+                assertThrows(IllegalStateException.class, () -> listenerUnderTest.onAfterConvert(event));
+        assertThat(exception.getMessage(), is("Error parsing item options JSON: Test message"));
+
+        // Then
+        verify(items).get(0);
+        verify(certificateItem).getKind();
+        verify(mapper).readValue("{}", CertificateItemOptions.class);
+        verify(certificateItem, never()).setItemOptions(certificateItemOptions);
+
+    }
+
+    // TODO GCI-984 Test certified copy item options too
+
+    @Test
+    @DisplayName("onAfterConvert() throws IllegalStateException if no order document found on event")
+    void onAfterConvertThrowsIllegalStateExceptionIfNoOrderDocumentFoundOnEvent() {
+        final IllegalStateException exception =
+                assertThrows(IllegalStateException.class, () -> listenerUnderTest.onAfterConvert(event));
+        assertThat(exception.getMessage(), is("No order document found on event."));
+    }
+
+    @Test
+    @DisplayName("getType() infers item options class type correctly from kind")
+    void getTypeInfersItemOptionsClassCorrectlyFromKind() {
+        assertEquals(CertificateItemOptions.class, listenerUnderTest.getType(CERTIFICATE_KIND).getOptionsType());
+        assertEquals(CertifiedCopyItemOptions.class, listenerUnderTest.getType(CERTIFIED_COPY_KIND).getOptionsType());
+    }
+
+    @Test
+    @DisplayName("getType() throws IllegalArgumentException for unknown kind")
+    void getTypeThrowsIllegalArgumentExceptionForUnknownKind() {
+        final IllegalArgumentException exception =
+                assertThrows(IllegalArgumentException.class, () -> listenerUnderTest.getType(UNKNOWN_KIND));
+        assertEquals("'" + UNKNOWN_KIND + "' is not a known kind!", exception.getMessage());
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/orders/api/listener/OrderItemOptionsReaderTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/listener/OrderItemOptionsReaderTest.java
@@ -1,0 +1,173 @@
+package uk.gov.companieshouse.orders.api.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bson.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.orders.api.model.CertificateItemOptions;
+import uk.gov.companieshouse.orders.api.model.CertifiedCopyItemOptions;
+import uk.gov.companieshouse.orders.api.model.Item;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.CERTIFICATE_KIND;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.CERTIFIED_COPY_KIND;
+
+/**
+ * Unit tests the {@link OrderItemOptionsReader} component.
+ */
+@ExtendWith(MockitoExtension.class)
+class OrderItemOptionsReaderTest {
+
+    private static final String UNKNOWN_KIND = "item#unknown";
+
+    @InjectMocks
+    private OrderItemOptionsReader readerUnderTest;
+
+    @Mock
+    private Document checkoutDocument;
+
+    @Mock
+    private List<Item> items;
+
+    @Mock
+    private Item certificateItem;
+
+    @Mock
+    private Document checkoutDataDocument;
+
+    @Mock
+    private List<Document> itemDocuments;
+
+    @Mock
+    private Document itemDocument;
+
+    @Mock
+    private ObjectMapper mapper;
+
+    @Mock
+    private Document optionsDocument;
+
+    @Mock
+    private CertificateItemOptions certificateItemOptions;
+
+    @Test
+    @DisplayName("readOrderItemsOptions() updates item options correctly")
+    void readOrderItemsOptionsUpdatesCertificateItemOptionsCorrectly() throws IOException {
+
+        // Given
+        when(items.size()).thenReturn(1);
+        when(items.get(0)).thenReturn(certificateItem);
+
+        when(checkoutDocument.get("data", Document.class)).thenReturn(checkoutDataDocument);
+        when(checkoutDataDocument.get("items", List.class)).thenReturn(itemDocuments);
+        when(itemDocuments.get(0)).thenReturn(itemDocument);
+        when(itemDocument.get("item_options", Document.class)).thenReturn(optionsDocument);
+        when(optionsDocument.toJson()).thenReturn("{}");
+        when(certificateItem.getKind()).thenReturn(CERTIFICATE_KIND);
+        when(mapper.readValue("{}", CertificateItemOptions.class)).thenReturn(certificateItemOptions);
+
+        // When
+        readerUnderTest.readOrderItemsOptions(items, checkoutDocument, "checkout");
+
+        // Then
+        verify(items).get(0);
+        verify(certificateItem).getKind();
+        verify(mapper).readValue("{}", CertificateItemOptions.class);
+        verify(certificateItem).setItemOptions(certificateItemOptions);
+
+    }
+
+    @Test
+    @DisplayName("readOrderItemsOptions() copes with missing item options")
+    void readOrderItemsOptionsCopesWithMissingItemOptions() throws IOException {
+
+        // Given
+        when(items.size()).thenReturn(1);
+        when(items.get(0)).thenReturn(certificateItem);
+
+        when(checkoutDocument.get("data", Document.class)).thenReturn(checkoutDataDocument);
+        when(checkoutDataDocument.get("items", List.class)).thenReturn(itemDocuments);
+        when(itemDocuments.get(0)).thenReturn(itemDocument);
+        when(itemDocument.get("item_options", Document.class)).thenReturn(null);
+
+        // When
+        readerUnderTest.readOrderItemsOptions(items, checkoutDocument, "checkout");
+
+        // Then
+        verify(items).get(0);
+        verify(mapper, never()).readValue(anyString(), ArgumentMatchers.eq(CertificateItemOptions.class));
+    }
+
+    @Test
+    @DisplayName("readOrderItemsOptions() propagates mapper IOException as an IllegalStateException")
+    void readOrderItemsOptionsPropagatesMapperIOExceptionAsIllegalStateException() throws IOException {
+
+        // Given
+        when(items.size()).thenReturn(1);
+        when(items.get(0)).thenReturn(certificateItem);
+
+        when(checkoutDocument.get("data", Document.class)).thenReturn(checkoutDataDocument);
+        when(checkoutDataDocument.get("items", List.class)).thenReturn(itemDocuments);
+        when(itemDocuments.get(0)).thenReturn(itemDocument);
+        when(itemDocument.get("item_options", Document.class)).thenReturn(optionsDocument);
+        when(optionsDocument.toJson()).thenReturn("{}");
+        when(certificateItem.getKind()).thenReturn(CERTIFICATE_KIND);
+        when(mapper.readValue("{}", CertificateItemOptions.class)).thenThrow(new IOException("Test message"));
+
+        // When and then
+        final IllegalStateException exception =
+                assertThrows(IllegalStateException.class,
+                        () -> readerUnderTest.readOrderItemsOptions(items, checkoutDocument, "checkout"));
+        assertThat(exception.getMessage(), is("Error parsing item options JSON: Test message"));
+
+        // Then
+        verify(items).get(0);
+        verify(certificateItem).getKind();
+        verify(mapper).readValue("{}", CertificateItemOptions.class);
+        verify(certificateItem, never()).setItemOptions(certificateItemOptions);
+
+    }
+
+    // TODO GCI-984 Test certified copy item options too
+
+    @Test
+    @DisplayName("readOrderItemsOptions() throws IllegalStateException if no checkout document found on event")
+    void readOrderItemsOptionsThrowsIllegalStateExceptionIfNoCheckoutDocumentFoundOnEvent() {
+        final IllegalStateException exception =
+                assertThrows(IllegalStateException.class,
+                        () -> readerUnderTest.readOrderItemsOptions(items, null, "checkout"));
+        assertThat(exception.getMessage(), is("No checkout document found on event."));
+    }
+
+
+    @Test
+    @DisplayName("getType() infers item options class type correctly from kind")
+    void getTypeInfersItemOptionsClassCorrectlyFromKind() {
+        assertEquals(CertificateItemOptions.class, readerUnderTest.getType(CERTIFICATE_KIND).getOptionsType());
+        assertEquals(CertifiedCopyItemOptions.class, readerUnderTest.getType(CERTIFIED_COPY_KIND).getOptionsType());
+    }
+
+    @Test
+    @DisplayName("getType() throws IllegalArgumentException for unknown kind")
+    void getTypeThrowsIllegalArgumentExceptionForUnknownKind() {
+        final IllegalArgumentException exception =
+                assertThrows(IllegalArgumentException.class, () -> readerUnderTest.getType(UNKNOWN_KIND));
+        assertEquals("'" + UNKNOWN_KIND + "' is not a known kind!", exception.getMessage());
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/orders/api/listener/OrderItemOptionsReaderTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/listener/OrderItemOptionsReaderTest.java
@@ -33,15 +33,14 @@ import static uk.gov.companieshouse.orders.api.util.TestConstants.CERTIFIED_COPY
 @ExtendWith(MockitoExtension.class)
 class OrderItemOptionsReaderTest {
 
-    // TODO GCI-984 Do we need to test reader behaviour for an order too?
-
     private static final String UNKNOWN_KIND = "item#unknown";
+    private static final String UNUSED_ORDER_TYPE_NAME = "'order' or 'checkout', value unused in this test.";
 
     @InjectMocks
     private OrderItemOptionsReader readerUnderTest;
 
     @Mock
-    private Document checkoutDocument;
+    private Document orderDocument;
 
     @Mock
     private List<Item> items;
@@ -53,7 +52,7 @@ class OrderItemOptionsReaderTest {
     private Item certifiedCopyItem;
 
     @Mock
-    private Document checkoutDataDocument;
+    private Document orderDataDocument;
 
     @Mock
     private List<Document> itemDocuments;
@@ -81,8 +80,8 @@ class OrderItemOptionsReaderTest {
         when(items.size()).thenReturn(1);
         when(items.get(0)).thenReturn(certificateItem);
 
-        when(checkoutDocument.get("data", Document.class)).thenReturn(checkoutDataDocument);
-        when(checkoutDataDocument.get("items", List.class)).thenReturn(itemDocuments);
+        when(orderDocument.get("data", Document.class)).thenReturn(orderDataDocument);
+        when(orderDataDocument.get("items", List.class)).thenReturn(itemDocuments);
         when(itemDocuments.get(0)).thenReturn(itemDocument);
         when(itemDocument.get("item_options", Document.class)).thenReturn(optionsDocument);
         when(optionsDocument.toJson()).thenReturn("{}");
@@ -90,7 +89,7 @@ class OrderItemOptionsReaderTest {
         when(mapper.readValue("{}", CertificateItemOptions.class)).thenReturn(certificateItemOptions);
 
         // When
-        readerUnderTest.readOrderItemsOptions(items, checkoutDocument, "checkout");
+        readerUnderTest.readOrderItemsOptions(items, orderDocument, UNUSED_ORDER_TYPE_NAME);
 
         // Then
         verify(items).get(0);
@@ -107,8 +106,8 @@ class OrderItemOptionsReaderTest {
         when(items.size()).thenReturn(1);
         when(items.get(0)).thenReturn(certifiedCopyItem);
 
-        when(checkoutDocument.get("data", Document.class)).thenReturn(checkoutDataDocument);
-        when(checkoutDataDocument.get("items", List.class)).thenReturn(itemDocuments);
+        when(orderDocument.get("data", Document.class)).thenReturn(orderDataDocument);
+        when(orderDataDocument.get("items", List.class)).thenReturn(itemDocuments);
         when(itemDocuments.get(0)).thenReturn(itemDocument);
         when(itemDocument.get("item_options", Document.class)).thenReturn(optionsDocument);
         when(optionsDocument.toJson()).thenReturn("{}");
@@ -116,7 +115,7 @@ class OrderItemOptionsReaderTest {
         when(mapper.readValue("{}", CertifiedCopyItemOptions.class)).thenReturn(certifiedCopyItemOptions);
 
         // When
-        readerUnderTest.readOrderItemsOptions(items, checkoutDocument, "checkout");
+        readerUnderTest.readOrderItemsOptions(items, orderDocument, UNUSED_ORDER_TYPE_NAME);
 
         // Then
         verify(items).get(0);
@@ -133,13 +132,13 @@ class OrderItemOptionsReaderTest {
         when(items.size()).thenReturn(1);
         when(items.get(0)).thenReturn(certificateItem);
 
-        when(checkoutDocument.get("data", Document.class)).thenReturn(checkoutDataDocument);
-        when(checkoutDataDocument.get("items", List.class)).thenReturn(itemDocuments);
+        when(orderDocument.get("data", Document.class)).thenReturn(orderDataDocument);
+        when(orderDataDocument.get("items", List.class)).thenReturn(itemDocuments);
         when(itemDocuments.get(0)).thenReturn(itemDocument);
         when(itemDocument.get("item_options", Document.class)).thenReturn(null);
 
         // When
-        readerUnderTest.readOrderItemsOptions(items, checkoutDocument, "checkout");
+        readerUnderTest.readOrderItemsOptions(items, orderDocument, UNUSED_ORDER_TYPE_NAME);
 
         // Then
         verify(items).get(0);
@@ -154,8 +153,8 @@ class OrderItemOptionsReaderTest {
         when(items.size()).thenReturn(1);
         when(items.get(0)).thenReturn(certificateItem);
 
-        when(checkoutDocument.get("data", Document.class)).thenReturn(checkoutDataDocument);
-        when(checkoutDataDocument.get("items", List.class)).thenReturn(itemDocuments);
+        when(orderDocument.get("data", Document.class)).thenReturn(orderDataDocument);
+        when(orderDataDocument.get("items", List.class)).thenReturn(itemDocuments);
         when(itemDocuments.get(0)).thenReturn(itemDocument);
         when(itemDocument.get("item_options", Document.class)).thenReturn(optionsDocument);
         when(optionsDocument.toJson()).thenReturn("{}");
@@ -165,7 +164,7 @@ class OrderItemOptionsReaderTest {
         // When and then
         final IllegalStateException exception =
                 assertThrows(IllegalStateException.class,
-                        () -> readerUnderTest.readOrderItemsOptions(items, checkoutDocument, "checkout"));
+                        () -> readerUnderTest.readOrderItemsOptions(items, orderDocument, UNUSED_ORDER_TYPE_NAME));
         assertThat(exception.getMessage(), is("Error parsing item options JSON: Test message"));
 
         // Then

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
@@ -7,11 +7,29 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import uk.gov.companieshouse.orders.api.model.*;
+import uk.gov.companieshouse.orders.api.model.ActionedBy;
+import uk.gov.companieshouse.orders.api.model.Certificate;
+import uk.gov.companieshouse.orders.api.model.CertificateItemOptions;
+import uk.gov.companieshouse.orders.api.model.CertifiedCopy;
+import uk.gov.companieshouse.orders.api.model.CertifiedCopyItemOptions;
+import uk.gov.companieshouse.orders.api.model.Checkout;
+import uk.gov.companieshouse.orders.api.model.CheckoutData;
+import uk.gov.companieshouse.orders.api.model.CheckoutLinks;
+import uk.gov.companieshouse.orders.api.model.CollectionLocation;
+import uk.gov.companieshouse.orders.api.model.DeliveryDetails;
+import uk.gov.companieshouse.orders.api.model.DeliveryMethod;
+import uk.gov.companieshouse.orders.api.model.DeliveryTimescale;
+import uk.gov.companieshouse.orders.api.model.DirectorOrSecretaryDetails;
+import uk.gov.companieshouse.orders.api.model.IncludeAddressRecordsType;
+import uk.gov.companieshouse.orders.api.model.IncludeDobType;
+import uk.gov.companieshouse.orders.api.model.ItemCosts;
+import uk.gov.companieshouse.orders.api.model.Order;
+import uk.gov.companieshouse.orders.api.model.RegisteredOfficeAddressDetails;
 
 import java.time.LocalDateTime;
 import java.util.Map;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,6 +43,7 @@ import static uk.gov.companieshouse.orders.api.model.IncludeAddressRecordsType.C
 import static uk.gov.companieshouse.orders.api.model.IncludeDobType.PARTIAL;
 import static uk.gov.companieshouse.orders.api.model.PaymentStatus.PAID;
 import static uk.gov.companieshouse.orders.api.model.ProductType.CERTIFICATE;
+import static uk.gov.companieshouse.orders.api.util.TestConstants.DOCUMENT;
 
 /**
  * Unit tests the {@link CheckoutToOrderMapperTest} class.
@@ -65,8 +84,11 @@ class CheckoutToOrderMapperTest {
 
     private static final IncludeAddressRecordsType INCLUDE_ADDRESS_RECORDS_TYPE = CURRENT;
     private static final boolean INCLUDE_DATES = true;
+    private static final String FORENAME = "John";
+    private static final String SURNAME = "Smith";
 
-    private static final CertificateItemOptions ITEM_OPTIONS;
+    private static final CertificateItemOptions CERTIFICATE_ITEM_OPTIONS;
+    private static final CertifiedCopyItemOptions CERTIFIED_COPY_ITEM_OPTIONS;
     private static final DirectorOrSecretaryDetails DIRECTOR_OR_SECRETARY_DETAILS;
     private static final RegisteredOfficeAddressDetails REGISTERED_OFFICE_ADDRESS_DETAILS;
     private static final DeliveryDetails DELIVERY_DETAILS;
@@ -87,18 +109,27 @@ class CheckoutToOrderMapperTest {
         REGISTERED_OFFICE_ADDRESS_DETAILS.setIncludeAddressRecordsType(INCLUDE_ADDRESS_RECORDS_TYPE);
         REGISTERED_OFFICE_ADDRESS_DETAILS.setIncludeDates(INCLUDE_DATES);
 
-        ITEM_OPTIONS = new CertificateItemOptions();
-        ITEM_OPTIONS.setCertificateType(INCORPORATION);
-        ITEM_OPTIONS.setCollectionLocation(BELFAST);
-        ITEM_OPTIONS.setContactNumber(CONTACT_NUMBER);
-        ITEM_OPTIONS.setDeliveryMethod(POSTAL);
-        ITEM_OPTIONS.setDeliveryTimescale(STANDARD);
-        ITEM_OPTIONS.setDirectorDetails(DIRECTOR_OR_SECRETARY_DETAILS);
-        ITEM_OPTIONS.setIncludeCompanyObjectsInformation(INCLUDE_COMPANY_OBJECTS_INFORMATION);
-        ITEM_OPTIONS.setIncludeEmailCopy(INCLUDE_EMAIL_COPY);
-        ITEM_OPTIONS.setIncludeGoodStandingInformation(INCLUDE_GOOD_STANDING_INFORMATION);
-        ITEM_OPTIONS.setRegisteredOfficeAddressDetails(REGISTERED_OFFICE_ADDRESS_DETAILS);
-        ITEM_OPTIONS.setSecretaryDetails(DIRECTOR_OR_SECRETARY_DETAILS);
+        CERTIFICATE_ITEM_OPTIONS = new CertificateItemOptions();
+        CERTIFICATE_ITEM_OPTIONS.setCertificateType(INCORPORATION);
+        CERTIFICATE_ITEM_OPTIONS.setCollectionLocation(BELFAST);
+        CERTIFICATE_ITEM_OPTIONS.setContactNumber(CONTACT_NUMBER);
+        CERTIFICATE_ITEM_OPTIONS.setDeliveryMethod(POSTAL);
+        CERTIFICATE_ITEM_OPTIONS.setDeliveryTimescale(STANDARD);
+        CERTIFICATE_ITEM_OPTIONS.setDirectorDetails(DIRECTOR_OR_SECRETARY_DETAILS);
+        CERTIFICATE_ITEM_OPTIONS.setIncludeCompanyObjectsInformation(INCLUDE_COMPANY_OBJECTS_INFORMATION);
+        CERTIFICATE_ITEM_OPTIONS.setIncludeEmailCopy(INCLUDE_EMAIL_COPY);
+        CERTIFICATE_ITEM_OPTIONS.setIncludeGoodStandingInformation(INCLUDE_GOOD_STANDING_INFORMATION);
+        CERTIFICATE_ITEM_OPTIONS.setRegisteredOfficeAddressDetails(REGISTERED_OFFICE_ADDRESS_DETAILS);
+        CERTIFICATE_ITEM_OPTIONS.setSecretaryDetails(DIRECTOR_OR_SECRETARY_DETAILS);
+
+        CERTIFIED_COPY_ITEM_OPTIONS = new CertifiedCopyItemOptions();
+        CERTIFIED_COPY_ITEM_OPTIONS.setCollectionLocation(CollectionLocation.BELFAST);
+        CERTIFIED_COPY_ITEM_OPTIONS.setContactNumber(CONTACT_NUMBER);
+        CERTIFIED_COPY_ITEM_OPTIONS.setDeliveryMethod(DeliveryMethod.POSTAL);
+        CERTIFIED_COPY_ITEM_OPTIONS.setDeliveryTimescale(DeliveryTimescale.STANDARD);
+        CERTIFIED_COPY_ITEM_OPTIONS.setFilingHistoryDocuments(singletonList(DOCUMENT));
+        CERTIFIED_COPY_ITEM_OPTIONS.setForename(FORENAME);
+        CERTIFIED_COPY_ITEM_OPTIONS.setSurname(SURNAME);
 
         DELIVERY_DETAILS = new DeliveryDetails();
         DELIVERY_DETAILS.setForename("George");
@@ -143,22 +174,40 @@ class CheckoutToOrderMapperTest {
         data.setReference(ORDER_REFERENCE);
         data.setPaidAt(time);
         data.setCheckedOutBy(ACTIONED_BY);
-        final Item item = new Item();
-        item.setCompanyName(COMPANY_NAME);
-        item.setCompanyNumber(COMPANY_NUMBER);
-        item.setCustomerReference(CUSTOMER_REFERENCE);
-        item.setQuantity(QUANTITY);
-        item.setDescription(DESCRIPTION);
-        item.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
-        item.setDescriptionValues(DESCRIPTION_VALUES);
-        item.setItemCosts(singletonList(ITEM_COSTS));
-        item.setPostageCost(POSTAGE_COST);
-        item.setTotalItemCost(TOTAL_ITEM_COST);
-        item.setKind(ITEM_KIND);
-        item.setPostalDelivery(POSTAL_DELIVERY);
-        item.setItemOptions(ITEM_OPTIONS);
-        item.setEtag(TOKEN_ETAG);
-        data.setItems(singletonList(item));
+
+        final Certificate checkoutCertificate = new Certificate();
+        checkoutCertificate.setCompanyName(COMPANY_NAME);
+        checkoutCertificate.setCompanyNumber(COMPANY_NUMBER);
+        checkoutCertificate.setCustomerReference(CUSTOMER_REFERENCE);
+        checkoutCertificate.setQuantity(QUANTITY);
+        checkoutCertificate.setDescription(DESCRIPTION);
+        checkoutCertificate.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
+        checkoutCertificate.setDescriptionValues(DESCRIPTION_VALUES);
+        checkoutCertificate.setItemCosts(singletonList(ITEM_COSTS));
+        checkoutCertificate.setPostageCost(POSTAGE_COST);
+        checkoutCertificate.setTotalItemCost(TOTAL_ITEM_COST);
+        checkoutCertificate.setKind(ITEM_KIND);
+        checkoutCertificate.setPostalDelivery(POSTAL_DELIVERY);
+        checkoutCertificate.setItemOptions(CERTIFICATE_ITEM_OPTIONS);
+        checkoutCertificate.setEtag(TOKEN_ETAG);
+
+        final CertifiedCopy checkoutCopy = new CertifiedCopy();
+        checkoutCopy.setCompanyName(COMPANY_NAME);
+        checkoutCopy.setCompanyNumber(COMPANY_NUMBER);
+        checkoutCopy.setCustomerReference(CUSTOMER_REFERENCE);
+        checkoutCopy.setQuantity(QUANTITY);
+        checkoutCopy.setDescription(DESCRIPTION);
+        checkoutCopy.setDescriptionIdentifier(DESCRIPTION_IDENTIFIER);
+        checkoutCopy.setDescriptionValues(DESCRIPTION_VALUES);
+        checkoutCopy.setItemCosts(singletonList(ITEM_COSTS));
+        checkoutCopy.setPostageCost(POSTAGE_COST);
+        checkoutCopy.setTotalItemCost(TOTAL_ITEM_COST);
+        checkoutCopy.setKind(ITEM_KIND);
+        checkoutCopy.setPostalDelivery(POSTAL_DELIVERY);
+        checkoutCopy.setItemOptions(CERTIFIED_COPY_ITEM_OPTIONS);
+        checkoutCopy.setEtag(TOKEN_ETAG);
+
+        data.setItems(asList(checkoutCertificate, checkoutCopy));
         checkout.setData(data);
         final Order order = mapperUnderTest.checkoutToOrder(checkout);
 
@@ -166,9 +215,6 @@ class CheckoutToOrderMapperTest {
         assertThat(order.getUserId(), is(checkout.getUserId()));
         assertThat(order.getData(), is(notNullValue()));
         assertThat(order.getData().getItems(), is(checkout.getData().getItems()));
-
-        // This assertion succeeds because the item is in fact the same instance.
-        assertThat(order.getData().getItems().get(0), is(checkout.getData().getItems().get(0)));
 
         assertThat(order.getData().getDeliveryDetails(), is(checkout.getData().getDeliveryDetails()));
         assertThat(order.getData().getEtag(), is(checkout.getData().getEtag()));
@@ -179,10 +225,15 @@ class CheckoutToOrderMapperTest {
         assertThat(order.getData().getReference(), is(checkout.getData().getReference()));
         assertThat(order.getData().getOrderedBy(), is(checkout.getData().getCheckedOutBy()));
 
-        org.assertj.core.api.Assertions.assertThat(order.getData().getItems().get(0).getItemOptions())
-                .isEqualToComparingFieldByField(checkout.getData().getItems().get(0).getItemOptions());
-    }
+        assertThat(order.getData().getItems().size(), is(2));
+        assertThat(order.getData().getItems().get(0) instanceof Certificate, is(true));
+        final Certificate orderCertificate = (Certificate) order.getData().getItems().get(0);
+        assertThat(order.getData().getItems().get(1) instanceof CertifiedCopy, is(true));
+        final CertifiedCopy orderCopy = (CertifiedCopy) order.getData().getItems().get(1);
 
-    // TODO GCI-984 Implement test for certified copy mapping?
+        org.assertj.core.api.Assertions.assertThat(orderCertificate).isEqualToComparingFieldByField(checkoutCertificate);
+        org.assertj.core.api.Assertions.assertThat(orderCopy).isEqualToComparingFieldByField(checkoutCopy);
+
+    }
 
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
@@ -178,6 +178,9 @@ public class CheckoutToOrderMapperTest {
         assertThat(order.getData().getTotalOrderCost(), is(checkout.getData().getTotalOrderCost()));
         assertThat(order.getData().getReference(), is(checkout.getData().getReference()));
         assertThat(order.getData().getOrderedBy(), is(checkout.getData().getCheckedOutBy()));
+
+        org.assertj.core.api.Assertions.assertThat(order.getData().getItems().get(0).getItemOptions())
+                .isEqualToComparingFieldByField(checkout.getData().getItems().get(0).getItemOptions());
     }
 
     // TODO GCI-984 Implement test for certified copy mapping?

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToOrderMapperTest.java
@@ -31,7 +31,7 @@ import static uk.gov.companieshouse.orders.api.model.ProductType.CERTIFICATE;
  */
 @ExtendWith(SpringExtension.class)
 @SpringJUnitConfig(CheckoutToOrderMapperTest.Config.class)
-public class CheckoutToOrderMapperTest {
+class CheckoutToOrderMapperTest {
 
     private static final String ID = "CHS00000000000000001";
     private static final String COMPANY_NUMBER = "00006444";

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapperTest.java
@@ -148,8 +148,6 @@ class CheckoutToPaymentDetailsMapperTest {
         testItems(source, target);
     }
 
-    // TODO GCI-984 Implement test for certified copy mapping?
-
     private void testItems(Checkout source, PaymentDetailsDTO target){
         assertEquals(target.getItems().size(), source.getData().getItems().get(0).getItemCosts().size());
         assertThat(target.getItems().get(0).getDescriptionIdentifier(), is(source.getData().getItems().get(0).getDescriptionIdentifier()));


### PR DESCRIPTION
* Refactor Mongo checkout reader to introduce similar Mongo order reader so that item options held within checkouts or orders can be read correctly from the database.
* Verify that the options are rendered correctly in responses and/or stored correctly in DB collections for `add item`, `get basket`, `checkout basket`, `patch successful payment` and `get order` scenarios/requests. 
* These changes should fix [GCI-1286](https://companieshouse.atlassian.net/browse/GCI-1286).
