### PR TITLE
Gci 1297 verify message is written to kafka topic

### DIFF
--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/GlobalExceptionHandler.java
@@ -9,8 +9,10 @@ import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import uk.gov.companieshouse.orders.api.exception.KafkaMessagingException;
 import uk.gov.companieshouse.orders.api.model.ApiError;
 import uk.gov.companieshouse.orders.api.util.FieldNameConverter;
 
@@ -51,6 +53,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         }
 
         return super.handleHttpMessageNotReadable(ex, headers, status, request);
+    }
+
+    /**
+     * Returns Http Status 500 when Kafka message sending fails
+     * @param ex exception
+     * @return
+     */
+    @ExceptionHandler(KafkaMessagingException.class)
+    public ResponseEntity<Object> handleKafkaMessagingException(final KafkaMessagingException ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ex.getMessage());
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/orders/api/exception/KafkaMessagingException.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/exception/KafkaMessagingException.java
@@ -1,8 +1,5 @@
 package uk.gov.companieshouse.orders.api.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 public class KafkaMessagingException extends RuntimeException {
 
     public KafkaMessagingException(String message) {

--- a/src/main/java/uk/gov/companieshouse/orders/api/exception/KafkaMessagingException.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/exception/KafkaMessagingException.java
@@ -2,8 +2,8 @@ package uk.gov.companieshouse.orders.api.exception;
 
 public class KafkaMessagingException extends RuntimeException {
 
-    public KafkaMessagingException(String message) {
-        super(message);
+    public KafkaMessagingException(String message, Throwable cause) {
+        super(message, cause);
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/exception/KafkaMessagingException.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/exception/KafkaMessagingException.java
@@ -1,0 +1,12 @@
+package uk.gov.companieshouse.orders.api.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+public class KafkaMessagingException extends RuntimeException {
+
+    public KafkaMessagingException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrderReceivedMessageProducer.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrderReceivedMessageProducer.java
@@ -48,7 +48,6 @@ public class OrderReceivedMessageProducer {
         } catch (Exception e) {
             final String errorMessage
                     = String.format("Kafka 'order-received' message could not be sent for order - %s", orderId);
-            logMap.put(LoggingUtils.ORDER_ID, orderId);
             logMap.put(LoggingUtils.EXCEPTION, e);
             LOGGER.error(errorMessage, logMap);
             throw new KafkaMessagingException(errorMessage);

--- a/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrderReceivedMessageProducer.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrderReceivedMessageProducer.java
@@ -43,7 +43,7 @@ public class OrderReceivedMessageProducer {
                 logMapCallback.put(LoggingUtils.TOPIC, topic);
                 logMapCallback.put(LoggingUtils.ORDER_ID, orderId);
                 logMapCallback.put(LoggingUtils.OFFSET, offset);
-                LoggerFactory.getLogger(APPLICATION_NAMESPACE).info("Message sent to Kafka topic", logMap);
+                LoggerFactory.getLogger(APPLICATION_NAMESPACE).info("Message sent to Kafka topic", logMapCallback);
             });
         } catch (Exception e) {
             final String errorMessage

--- a/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrderReceivedMessageProducer.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrderReceivedMessageProducer.java
@@ -32,7 +32,8 @@ public class OrderReceivedMessageProducer {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    public void sendMessage(final OrderReceived orderReceived) throws SerializationException {
+    public void sendMessage(final OrderReceived orderReceived)
+            throws SerializationException, ExecutionException, InterruptedException {
         Message message = ordersAvroSerializer.createMessage(orderReceived);
         LOGGER.info("Sending message to kafka producer");
         ordersKafkaProducer.sendMessage(message, recordMetadata -> {

--- a/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrderReceivedMessageProducer.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrderReceivedMessageProducer.java
@@ -35,11 +35,11 @@ public class OrderReceivedMessageProducer {
     public void sendMessage(final OrderReceived orderReceived) throws SerializationException {
         Message message = ordersAvroSerializer.createMessage(orderReceived);
         LOGGER.info("Sending message to kafka producer");
-        ordersKafkaProducer.sendMessage(message, (recordMetadata) -> {
+        ordersKafkaProducer.sendMessage(message, recordMetadata -> {
             long offset = recordMetadata.offset();
             String topic = message.getTopic();
             String orderUri = orderReceived.getOrderUri();
-            Map<String, Object> logMap = new HashMap<String, Object>();
+            Map<String, Object> logMap = new HashMap<>();
             logMap.put(LoggingUtils.TOPIC, topic);
             logMap.put(LoggingUtils.ORDER_ID, orderUri.substring(8));
             logMap.put(LoggingUtils.OFFSET, offset);

--- a/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrderReceivedMessageProducer.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrderReceivedMessageProducer.java
@@ -50,7 +50,7 @@ public class OrderReceivedMessageProducer {
                     = String.format("Kafka 'order-received' message could not be sent for order - %s", orderId);
             logMap.put(LoggingUtils.EXCEPTION, e);
             LOGGER.error(errorMessage, logMap);
-            throw new KafkaMessagingException(errorMessage);
+            throw new KafkaMessagingException(errorMessage, e);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducer.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducer.java
@@ -35,27 +35,11 @@ public class OrdersKafkaProducer implements InitializingBean {
      * @throws InterruptedException
      */
     @Async
-    public void sendMessage(final Message message, Consumer<RecordMetadata> asyncResposnseLogger) {
+    public void sendMessage(final Message message, Consumer<RecordMetadata> asyncResposnseLogger)
+            throws ExecutionException, InterruptedException {
         LOGGER.info("Sending message to kafka topic");
-        try {
-            Future<RecordMetadata> recordMetadataFuture = chKafkaProducer.sendAndReturnFuture(message);
-            asyncResposnseLogger.accept(recordMetadataFuture.get());
-        }
-        catch (InterruptedException ie) {
-            logException(message, ie);
-            Thread.currentThread().interrupt();
-        }
-        catch (ExecutionException e) {
-            logException(message, e);
-        }
-    }
-
-    private void logException(Message message, Exception e) {
-        Map<String, Object> logMap = LoggingUtils.createLogMap();
-        String orderUri = new String(message.getValue());
-        logMap.put(LoggingUtils.ORDER_ID, orderUri.substring(8));
-        LoggingUtils.logIfNotNull(logMap, LoggingUtils.EXCEPTION, e.getMessage());
-        LOGGER.info("Failed to send message to kafka topic", logMap);
+        Future<RecordMetadata> recordMetadataFuture = chKafkaProducer.sendAndReturnFuture(message);
+        asyncResposnseLogger.accept(recordMetadataFuture.get());
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducer.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducer.java
@@ -35,11 +35,11 @@ public class OrdersKafkaProducer implements InitializingBean {
      * @throws InterruptedException
      */
     @Async
-    public void sendMessage(final Message message, Consumer<RecordMetadata> asyncResposnseLogger)
+    public void sendMessage(final Message message, Consumer<RecordMetadata> asyncResponseLogger)
             throws ExecutionException, InterruptedException {
         LOGGER.info("Sending message to kafka topic");
         Future<RecordMetadata> recordMetadataFuture = chKafkaProducer.sendAndReturnFuture(message);
-        asyncResposnseLogger.accept(recordMetadataFuture.get());
+        asyncResponseLogger.accept(recordMetadataFuture.get());
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducer.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducer.java
@@ -15,7 +15,6 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.orders.api.logging.LoggingUtils;
 
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
@@ -44,10 +43,13 @@ public class OrdersKafkaProducer implements InitializingBean {
         }
         catch (InterruptedException | ExecutionException e) {
             Map<String, Object> logMap = LoggingUtils.createLogMap();
-            String orderUri = message.getValue().toString();
+            String orderUri = new String(message.getValue());
             logMap.put(LoggingUtils.ORDER_ID, orderUri.substring(8));
             LoggingUtils.logIfNotNull(logMap, LoggingUtils.EXCEPTION, e.getMessage());
             LOGGER.info("Failed to send message to kafka topic", logMap);
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducer.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducer.java
@@ -35,9 +35,12 @@ public class OrdersKafkaProducer implements InitializingBean {
      * @throws InterruptedException
      */
     @Async
-    public void sendMessage(final Message message, Consumer<RecordMetadata> asyncResponseLogger)
+    public void sendMessage(final String orderId, final Message message, Consumer<RecordMetadata> asyncResponseLogger)
             throws ExecutionException, InterruptedException {
-        LOGGER.info("Sending message to kafka topic");
+        Map<String, Object> logMap = LoggingUtils.createLogMap();
+        LoggingUtils.logIfNotNull(logMap, LoggingUtils.ORDER_ID, orderId);
+        LOGGER.info("Sending message to kafka topic", logMap);
+
         Future<RecordMetadata> recordMetadataFuture = chKafkaProducer.sendAndReturnFuture(message);
         asyncResponseLogger.accept(recordMetadataFuture.get());
     }

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/OrderService.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/OrderService.java
@@ -1,13 +1,7 @@
 package uk.gov.companieshouse.orders.api.service;
 
-import static uk.gov.companieshouse.orders.api.logging.LoggingUtils.APPLICATION_NAMESPACE;
-import java.time.LocalDateTime;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.orders.OrderReceived;
@@ -19,6 +13,12 @@ import uk.gov.companieshouse.orders.api.model.Checkout;
 import uk.gov.companieshouse.orders.api.model.Order;
 import uk.gov.companieshouse.orders.api.repository.OrderRepository;
 
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import static uk.gov.companieshouse.orders.api.logging.LoggingUtils.APPLICATION_NAMESPACE;
+
 @Service
 public class OrderService {
 
@@ -27,8 +27,7 @@ public class OrderService {
     private final CheckoutToOrderMapper mapper;
     private final OrderRepository repository;
     private final LinksGeneratorService linksGeneratorService;
-
-    private OrderReceivedMessageProducer ordersMessageProducer;
+    private final OrderReceivedMessageProducer ordersMessageProducer;
 
     @Value("${uk.gov.companieshouse.orders.api.orders}")
     private String orderEndpointU;
@@ -65,13 +64,8 @@ public class OrderService {
             }
         );
 
-        try {
-            LOGGER.info("Publishing notification to Kafka 'order-received' topic for order - " + mappedOrder.getId(), logMap);
-            sendOrderReceivedMessage(mappedOrder.getId());
-        } catch (Exception e) {
-            logMap.put(LoggingUtils.EXCEPTION, e);
-            LOGGER.error("Kafka 'order-received' message could not be sent for order - " + mappedOrder.getId(), logMap);
-        }
+        LOGGER.info("Publishing notification to Kafka 'order-received' topic for order - " + mappedOrder.getId(), logMap);
+        sendOrderReceivedMessage(mappedOrder.getId());
 
         return repository.save(mappedOrder);
     }
@@ -82,16 +76,12 @@ public class OrderService {
     /**
      * Sends a message to Kafka topic 'order-received'
      * @param orderId order id
-     * @throws InterruptedException
-     * @throws ExecutionException
-     * @throws SerializationException
      */
-    private void sendOrderReceivedMessage(String orderId)
-            throws InterruptedException, ExecutionException, SerializationException {
+    private void sendOrderReceivedMessage(String orderId) {
         String orderURI = orderEndpointU + "/" + orderId;
         OrderReceived orderReceived = new OrderReceived();
         orderReceived.setOrderUri(orderURI);
-        ordersMessageProducer.sendMessage(orderReceived);
+        ordersMessageProducer.sendMessage(orderId, orderReceived);
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducerIntegrationTest.java
@@ -1,15 +1,10 @@
 package uk.gov.companieshouse.orders.api.kafka;
 
 import org.junit.Assert;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
 import uk.gov.companieshouse.kafka.exceptions.SerializationException;
@@ -17,10 +12,6 @@ import uk.gov.companieshouse.kafka.message.Message;
 import uk.gov.companieshouse.orders.OrderReceived;
 
 import java.util.concurrent.ExecutionException;
-
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @SpringBootTest
 @DirtiesContext

--- a/src/test/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducerIntegrationTest.java
@@ -1,0 +1,41 @@
+package uk.gov.companieshouse.orders.api.kafka;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import uk.gov.companieshouse.kafka.exceptions.SerializationException;
+import uk.gov.companieshouse.kafka.message.Message;
+import uk.gov.companieshouse.orders.OrderReceived;
+
+@SpringBootTest
+@DirtiesContext
+@EmbeddedKafka
+public class OrdersKafkaProducerIntegrationTest {
+    @Autowired
+    private OrdersKafkaProducer ordersKafkaProducer;
+
+    @Autowired
+    private OrdersMessageFactory ordersAvroSerializer;
+
+    private String ORDERS_URI = "/orders/123456";
+
+    private Message createTestMessage() throws SerializationException {
+        OrderReceived orderReceived = new OrderReceived(ORDERS_URI);
+        return ordersAvroSerializer.createMessage(orderReceived);
+    }
+
+    @Test
+    void testSendMessage() throws SerializationException {
+        // given an Order message is created
+        Message message = createTestMessage();
+
+        // when message is sent to Kafka topic
+        // then offset of the sent message is received
+        ordersKafkaProducer.sendMessage(message, (recordMetadata) -> {
+            Assert.assertNotNull(recordMetadata.offset());
+        });
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducerIntegrationTest.java
@@ -1,24 +1,48 @@
 package uk.gov.companieshouse.orders.api.kafka;
 
 import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
 import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.kafka.message.Message;
 import uk.gov.companieshouse.orders.OrderReceived;
 
+import java.util.concurrent.ExecutionException;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 @SpringBootTest
 @DirtiesContext
 @EmbeddedKafka
 public class OrdersKafkaProducerIntegrationTest {
+    @Value("${spring.kafka.consumer.bootstrap-servers}")
+    private String kafkaBrokerAddresses;
     @Autowired
     private OrdersKafkaProducer ordersKafkaProducer;
 
     @Autowired
     private OrdersMessageFactory ordersAvroSerializer;
+
+    private OrderReceivedMessageProducer orderReceivedMessageProducer;
+
+    @MockBean
+    private OrdersKafkaProducer ordersKafkaProducerMock;
+    @MockBean
+    private InterruptedException interruptedException;
+    @MockBean
+    private ExecutionException executionException;
+    private OrderReceivedMessageProducer orderReceivedMessageProducerSpy;
 
     private String ORDERS_URI = "/orders/123456";
 
@@ -27,8 +51,16 @@ public class OrdersKafkaProducerIntegrationTest {
         return ordersAvroSerializer.createMessage(orderReceived);
     }
 
+    @BeforeEach
+    void setUp(){
+        OrderReceivedMessageProducer orderReceivedMessageProducer
+                = new OrderReceivedMessageProducer(ordersAvroSerializer, ordersKafkaProducerMock);
+        orderReceivedMessageProducerSpy = Mockito.spy(orderReceivedMessageProducer);
+    }
+
     @Test
-    void testSendMessage() throws SerializationException {
+    @DisplayName("sendMessage successfully returns offset of sent message")
+    void testSendMessage() throws SerializationException, ExecutionException, InterruptedException {
         // given an Order message is created
         Message message = createTestMessage();
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducerIntegrationTest.java
@@ -26,36 +26,17 @@ import static org.mockito.Mockito.verify;
 @DirtiesContext
 @EmbeddedKafka
 public class OrdersKafkaProducerIntegrationTest {
-    @Value("${spring.kafka.consumer.bootstrap-servers}")
-    private String kafkaBrokerAddresses;
     @Autowired
     private OrdersKafkaProducer ordersKafkaProducer;
 
     @Autowired
     private OrdersMessageFactory ordersAvroSerializer;
 
-    private OrderReceivedMessageProducer orderReceivedMessageProducer;
-
-    @MockBean
-    private OrdersKafkaProducer ordersKafkaProducerMock;
-    @MockBean
-    private InterruptedException interruptedException;
-    @MockBean
-    private ExecutionException executionException;
-    private OrderReceivedMessageProducer orderReceivedMessageProducerSpy;
-
     private String ORDERS_URI = "/orders/123456";
 
     private Message createTestMessage() throws SerializationException {
         OrderReceived orderReceived = new OrderReceived(ORDERS_URI);
         return ordersAvroSerializer.createMessage(orderReceived);
-    }
-
-    @BeforeEach
-    void setUp(){
-        OrderReceivedMessageProducer orderReceivedMessageProducer
-                = new OrderReceivedMessageProducer(ordersAvroSerializer, ordersKafkaProducerMock);
-        orderReceivedMessageProducerSpy = Mockito.spy(orderReceivedMessageProducer);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/kafka/OrdersKafkaProducerIntegrationTest.java
@@ -3,6 +3,10 @@ package uk.gov.companieshouse.orders.api.kafka;
 import org.junit.Assert;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.test.context.EmbeddedKafka;
@@ -10,8 +14,18 @@ import org.springframework.test.annotation.DirtiesContext;
 import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.kafka.message.Message;
 import uk.gov.companieshouse.orders.OrderReceived;
+import uk.gov.companieshouse.orders.api.controller.GlobalExceptionHandler;
+import uk.gov.companieshouse.orders.api.exception.KafkaMessagingException;
 
 import java.util.concurrent.ExecutionException;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @DirtiesContext
@@ -20,26 +34,91 @@ public class OrdersKafkaProducerIntegrationTest {
     @Autowired
     private OrdersKafkaProducer ordersKafkaProducer;
 
+    @Spy
+    @InjectMocks
+    private OrderReceivedMessageProducer orderReceivedMessageProducer;
+    @Mock
+    private OrdersKafkaProducer ordersKafkaProducerMock;
+    @Mock
+    private GlobalExceptionHandler exceptionHandlerMock;
+    @Mock
+    private ExecutionException executionExceptionMock;
+    @Mock
+    private InterruptedException interruptedExceptionMock;
+    @Mock
+    private SerializationException serializationExceptionMock;
+    @Mock
+    private OrdersMessageFactory ordersMessageFactoryMock;
+
     @Autowired
     private OrdersMessageFactory ordersAvroSerializer;
-
-    private String ORDERS_URI = "/orders/123456";
+    private String ORDER_ID = "123456";
+    private String ORDERS_URI = "/orders/" + ORDER_ID;
+    private OrderReceived orderReceived = new OrderReceived(ORDERS_URI);
 
     private Message createTestMessage() throws SerializationException {
-        OrderReceived orderReceived = new OrderReceived(ORDERS_URI);
         return ordersAvroSerializer.createMessage(orderReceived);
     }
 
     @Test
     @DisplayName("sendMessage successfully returns offset of sent message")
     void testSendMessage() throws SerializationException, ExecutionException, InterruptedException {
-        // given an Order message is created
+        // given a Kafka message is requested to be sent
+        // and an Order message is created
         Message message = createTestMessage();
 
         // when message is sent to Kafka topic
         // then offset of the sent message is received
-        ordersKafkaProducer.sendMessage(message, (recordMetadata) -> {
+        ordersKafkaProducer.sendMessage(ORDER_ID, message, (recordMetadata) -> {
             Assert.assertNotNull(recordMetadata.offset());
+        });
+    }
+
+    @Test
+    @DisplayName("sendMessage throws KafkaMessagingException when ExecutionException is caught.")
+    void testExecutionExceptionHandling() throws SerializationException, ExecutionException, InterruptedException {
+        // given a Kafka message is requested to be sent
+        // and an Order message is created
+        Message message = createTestMessage();
+        when(ordersMessageFactoryMock.createMessage(any())).thenReturn(message);
+
+        // when ExecutionException is thrown while sending Kafka message
+        // then KafkaMessagingException is thrown and handled by GlobalExceptionHandler advice
+        doThrow(executionExceptionMock).when(ordersKafkaProducerMock).sendMessage(ORDER_ID, message, recordMetadata -> {
+            assertThrows(KafkaMessagingException.class, () -> orderReceivedMessageProducer.sendMessage(ORDER_ID, orderReceived));
+            verify(exceptionHandlerMock, times(1)).handleKafkaMessagingException(Mockito.any());
+        });
+        orderReceivedMessageProducer.sendMessage(ORDER_ID, orderReceived);
+    }
+
+    @Test
+    @DisplayName("sendMessage throws KafkaMessagingException when InterruptedException is caught.")
+    void testInterruptedExceptionHandling() throws SerializationException, ExecutionException, InterruptedException {
+        // given a Kafka message is requested to be sent
+        // and an Order message is created
+        Message message = createTestMessage();
+        when(ordersMessageFactoryMock.createMessage(any())).thenReturn(message);
+
+        // when InterruptedException is thrown while sending Kafka message
+        // then KafkaMessagingException is thrown and handled by GlobalExceptionHandler advice
+        doThrow(interruptedExceptionMock).when(ordersKafkaProducerMock).sendMessage(ORDER_ID, message, recordMetadata -> {
+            assertThrows(KafkaMessagingException.class, () -> orderReceivedMessageProducer.sendMessage(ORDER_ID, orderReceived));
+            verify(exceptionHandlerMock, times(1)).handleKafkaMessagingException(Mockito.any());
+        });
+        orderReceivedMessageProducer.sendMessage(ORDER_ID, orderReceived);
+    }
+
+    @Test
+    @DisplayName("sendMessage throws KafkaMessagingException when message creation fails.")
+    void testMessageCreationFailure() throws SerializationException {
+        // given a Kafka message is requested to be sent
+        // when Order message creation fails with SerializationException
+        when(ordersMessageFactoryMock.createMessage(any())).thenThrow(serializationExceptionMock);
+
+        // then KafkaMessagingException is thrown and handled by GlobalExceptionHandler advice
+        assertThrows(KafkaMessagingException.class, () -> {
+            orderReceivedMessageProducer.sendMessage(ORDER_ID, orderReceived);
+            verify(exceptionHandlerMock, times(1)).handleKafkaMessagingException(Mockito.any());
         });
     }
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/kafka/OrdersMessageProducerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/kafka/OrdersMessageProducerIntegrationTest.java
@@ -22,7 +22,8 @@ import static org.junit.Assert.assertEquals;
 @EmbeddedKafka
 @TestPropertySource(properties="uk.gov.companieshouse.orders.api.order=/order")
 public class OrdersMessageProducerIntegrationTest {
-    private static final String ORDER_URI = "/order/ORDER-12345";
+    private static final String ORDER_ID = "ORDER-12345";
+    private static final String ORDER_URI = "/order/" + ORDER_ID;
 
     @Autowired
     OrderReceivedMessageProducer ordersMessageProducerUnderTest;
@@ -40,7 +41,7 @@ public class OrdersMessageProducerIntegrationTest {
         orderReceived.setOrderUri(ORDER_URI);
 
         // When order-received message is sent to kafka topic
-        List<Message> messages = sendAndConsumeMessage(orderReceived);
+        List<Message> messages = sendAndConsumeMessage(ORDER_ID, orderReceived);
 
         // Then we have successfully consumed a message.
         assertThat(messages.isEmpty(), is(false));
@@ -55,13 +56,13 @@ public class OrdersMessageProducerIntegrationTest {
         assertEquals(deserializedConsumedMessage, deserializedOrderReceived);
     }
 
-    private List<Message> sendAndConsumeMessage(final OrderReceived orderReceived) throws Exception {
+    private List<Message> sendAndConsumeMessage(final String orderId, final OrderReceived orderReceived) throws Exception {
         List<Message> messages;
         testOrdersMessageConsumer.connect();
         int count = 0;
         do {
             messages = testOrdersMessageConsumer.pollConsumerGroup();
-            ordersMessageProducerUnderTest.sendMessage(orderReceived);
+            ordersMessageProducerUnderTest.sendMessage(orderId, orderReceived);
             count++;
         } while(messages.isEmpty() && count < 15);
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/OrderServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/OrderServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.orders.api.kafka.OrderReceivedMessageProducer;
 import uk.gov.companieshouse.orders.api.mapper.CheckoutToOrderMapper;
 import uk.gov.companieshouse.orders.api.model.Checkout;
 import uk.gov.companieshouse.orders.api.model.Order;
@@ -38,6 +39,9 @@ class OrderServiceTest {
 
     @Mock
     private LinksGeneratorService linksGeneratorService;
+
+    @Mock
+    private OrderReceivedMessageProducer ordersMessageProducer;
 
     @Test
     void createOrderCreatesOrder() {


### PR DESCRIPTION
This change replaces the `send()` method call with async call to `sendAndReturnFuture()` that returns the `offset` of the message sent to Kafka topic. The received `offset` is logged together with `order_id` for ease traceability.