### PR TITLE
Add support for filing history category attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<system-rules-version>1.17.2</system-rules-version>
 		<spring-cloud-contract-wiremock-version>2.2.2.RELEASE</spring-cloud-contract-wiremock-version>
 		<start-class>uk.gov.companieshouse.orders.api.OrdersApiApplication</start-class>
-		<private-api-sdk-java.version>2.0.52</private-api-sdk-java.version>
+		<private-api-sdk-java.version>2.0.54</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>1.0.3</api-sdk-manager-java-library.version>
 		<api-sdk-java.version>4.1.48</api-sdk-java.version>
 		<api-helper-java.version>1.4.1</api-helper-java.version>

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/MissingImageDeliveryItemOptions.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/MissingImageDeliveryItemOptions.java
@@ -14,6 +14,8 @@ public class MissingImageDeliveryItemOptions extends ItemOptions{
 
     private String filingHistoryType;
 
+    private String filingHistoryCategory;
+
     public String getFilingHistoryDate() {
         return filingHistoryDate;
     }
@@ -52,5 +54,13 @@ public class MissingImageDeliveryItemOptions extends ItemOptions{
 
     public void setFilingHistoryType(String filingHistoryType) {
         this.filingHistoryType = filingHistoryType;
+    }
+
+    public String getFilingHistoryCategory() {
+        return filingHistoryCategory;
+    }
+
+    public void setFilingHistoryCategory(String filingHistoryCategory) {
+        this.filingHistoryCategory = filingHistoryCategory;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -191,6 +191,7 @@ class BasketControllerIntegrationTest {
         put("officer_name", "Thomas David Wheare");
     }};
     private static final String MISSING_IMAGE_DELIVERY_FHD_TYPE = "CH01";
+    private static final String MISSING_IMAGE_DELIVERY_FHD_CATEGORY = "accounts";
 
     private static final MissingImageDeliveryItemOptions MISSING_IMAGE_DELIVERY_ITEM_OPTIONS;
 
@@ -201,6 +202,7 @@ class BasketControllerIntegrationTest {
         MISSING_IMAGE_DELIVERY_ITEM_OPTIONS.setFilingHistoryDescription(MISSING_IMAGE_DELIVERY_FHD_DESCRIPTION);
         MISSING_IMAGE_DELIVERY_ITEM_OPTIONS.setFilingHistoryDescriptionValues(MID_FHD_DESCRIPTION_VALUES);
         MISSING_IMAGE_DELIVERY_ITEM_OPTIONS.setFilingHistoryType(MISSING_IMAGE_DELIVERY_FHD_TYPE);
+        MISSING_IMAGE_DELIVERY_ITEM_OPTIONS.setFilingHistoryCategory(MISSING_IMAGE_DELIVERY_FHD_CATEGORY);
     }
 
     @Autowired
@@ -668,6 +670,8 @@ class BasketControllerIntegrationTest {
                         is(MISSING_IMAGE_DELIVERY_FHD_ID)))
                 .andExpect(jsonPath("$.items[0].item_options.filing_history_type",
                         is(MISSING_IMAGE_DELIVERY_FHD_TYPE)))
+                .andExpect(jsonPath("$.items[0].item_options.filing_history_category",
+                        is(MISSING_IMAGE_DELIVERY_FHD_CATEGORY)))
                 .andDo(MockMvcResultHandlers.print());
 
         final MockHttpServletResponse response = resultActions.andReturn().getResponse();


### PR DESCRIPTION
Add `filing_history_category` attribute to `item_options`