### PR TITLE
Update jacoco config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,6 @@
 		<commons.beanutils.version>1.9.4</commons.beanutils.version>
 		<org.mapstruct.version>1.3.0.Final</org.mapstruct.version>
 		<gson.version>2.8.0</gson.version>
-		<jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
 		<junit-jupiter-engine-version>5.2.0</junit-jupiter-engine-version>
 		<mockito-junit-jupiter-version>2.18.0</mockito-junit-jupiter-version>
 		<hamcrest-all-version>1.3</hamcrest-all-version>
@@ -206,21 +205,6 @@
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>${jacoco-maven-plugin.version}</version>
-				<executions>
-					<execution>
-						<id>default-prepare-agent</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>default-report</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.gov.companieshouse</groupId>
 		<artifactId>companies-house-parent</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0</version>
 	</parent>
 	<artifactId>orders.api.ch.gov.uk</artifactId>
 	<version>unversioned</version>


### PR DESCRIPTION
Jacoco reports are not being generated correctly resulting in code coverage being reported as 0% in Sonar. This will fix the issue by removing the Jacoco config and pointing to a newer version of the parent pom which contains the correct config.