### PR TITLE
Remove Spring Data REST

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-rest</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.orders.api.controller;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +21,7 @@ import uk.gov.companieshouse.orders.api.dto.BasketPaymentRequestDTO;
 import uk.gov.companieshouse.orders.api.dto.PaymentDetailsDTO;
 import uk.gov.companieshouse.orders.api.exception.ConflictException;
 import uk.gov.companieshouse.orders.api.exception.ErrorType;
+import uk.gov.companieshouse.orders.api.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.orders.api.logging.LoggingUtils;
 import uk.gov.companieshouse.orders.api.mapper.BasketMapper;
 import uk.gov.companieshouse.orders.api.mapper.CheckoutToPaymentDetailsMapper;

--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/OrderController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/OrderController.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.orders.api.controller;
 
-import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.orders.api.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.orders.api.logging.LoggingUtils;
 import uk.gov.companieshouse.orders.api.model.Order;
 import uk.gov.companieshouse.orders.api.model.OrderData;

--- a/src/main/java/uk/gov/companieshouse/orders/api/exception/ResourceNotFoundException.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/exception/ResourceNotFoundException.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.orders.api.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+
+    private static final long serialVersionUID = -5985187935862567975L;
+
+    public ResourceNotFoundException() {
+        this("Resource not found!");
+    }
+
+    public ResourceNotFoundException(String message) {
+        this(message, null);
+    }
+
+    public ResourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthorisationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthorisationInterceptor.java
@@ -1,12 +1,12 @@
 package uk.gov.companieshouse.orders.api.interceptor;
 
-import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import uk.gov.companieshouse.api.util.security.AuthorisationUtil;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.orders.api.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.orders.api.logging.LoggingUtils;
 import uk.gov.companieshouse.orders.api.model.AbstractOrder;
 import uk.gov.companieshouse.orders.api.repository.CheckoutRepository;

--- a/src/main/java/uk/gov/companieshouse/orders/api/repository/BasketRepository.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/repository/BasketRepository.java
@@ -1,8 +1,9 @@
 package uk.gov.companieshouse.orders.api.repository;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
 import uk.gov.companieshouse.orders.api.model.Basket;
 
-@RepositoryRestResource
+@Repository
 public interface BasketRepository extends MongoRepository<Basket, String>, BasketRepositoryCustom { }

--- a/src/main/java/uk/gov/companieshouse/orders/api/repository/CheckoutRepository.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/repository/CheckoutRepository.java
@@ -1,9 +1,10 @@
 package uk.gov.companieshouse.orders.api.repository;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
 import uk.gov.companieshouse.orders.api.model.Checkout;
 
-@RepositoryRestResource
+@Repository
 public interface CheckoutRepository extends MongoRepository<Checkout, String> {
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/repository/OrderRepository.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/repository/OrderRepository.java
@@ -1,8 +1,9 @@
 package uk.gov.companieshouse.orders.api.repository;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
 import uk.gov.companieshouse.orders.api.model.Order;
 
-@RepositoryRestResource
+@Repository
 public interface OrderRepository extends MongoRepository<Order, String> { }


### PR DESCRIPTION
Using `@RepositoryRestResource` is generating a separate set of endpoints that we do not want to expose.
We'll remove the Spring Data REST dependency and keep just our defined endpoints.