### PR TITLE
Bump api-security-java library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <api-sdk-manager-java-library.version>1.0.3</api-sdk-manager-java-library.version>
         <api-sdk-java.version>4.1.48</api-sdk-java.version>
         <api-helper-java.version>1.4.1</api-helper-java.version>
-        <api-security-java.version>0.2.16</api-security-java.version>
+        <api-security-java.version>0.3.0</api-security-java.version>
         <spring-boot-dependencies.version>2.1.15.RELEASE</spring-boot-dependencies.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
@@ -53,6 +53,10 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>private-api-sdk-java</artifactId>


### PR DESCRIPTION
Upgrade to the latest version which limits transitive dependencies.
Explicitly add `spring-boot-starter-web` which used to be a transitive dependency of `api-security-java`