### PR TITLE
BI-10173 Add company status field to item options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <structured-logging.version>1.9.12</structured-logging.version>
         <commons.lang.version>2.6</commons.lang.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
-        <org.mapstruct.version>1.3.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.4.2.Final</org.mapstruct.version>
         <gson.version>2.8.0</gson.version>
         <hamcrest-all-version>1.3</hamcrest-all-version>
         <!-- system-rules: 1.17.2 is the latest version that works with JUnit 5.
@@ -28,7 +28,7 @@
         <system-rules-version>1.17.2</system-rules-version>
         <spring-cloud-contract-wiremock-version>2.2.2.RELEASE</spring-cloud-contract-wiremock-version>
         <start-class>uk.gov.companieshouse.orders.api.OrdersApiApplication</start-class>
-        <private-api-sdk-java.version>2.0.102</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.103</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.3</api-sdk-manager-java-library.version>
         <api-sdk-java.version>4.3.3</api-sdk-java.version>
         <api-helper-java.version>1.4.1</api-helper-java.version>

--- a/src/main/java/uk/gov/companieshouse/orders/api/interceptor/LoggingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/interceptor/LoggingInterceptor.java
@@ -2,8 +2,8 @@ package uk.gov.companieshouse.orders.api.interceptor;
 
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.logging.util.RequestLogger;
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletResponse;
 import static uk.gov.companieshouse.orders.api.logging.LoggingUtils.APPLICATION_NAMESPACE;
 
 @Component
-public class LoggingInterceptor extends HandlerInterceptorAdapter implements RequestLogger {
+public class LoggingInterceptor implements HandlerInterceptor, RequestLogger {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
 

--- a/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthenticationInterceptor.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Service;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -26,7 +26,7 @@ import uk.gov.companieshouse.orders.api.logging.LoggingUtils;
 import uk.gov.companieshouse.orders.api.util.EricHeaderHelper;
 
 @Service
-public class UserAuthenticationInterceptor extends HandlerInterceptorAdapter {
+public class UserAuthenticationInterceptor implements HandlerInterceptor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
 

--- a/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthorisationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthorisationInterceptor.java
@@ -15,7 +15,7 @@ import static uk.gov.companieshouse.orders.api.logging.LoggingUtils.APPLICATION_
 import static uk.gov.companieshouse.orders.api.util.EricHeaderHelper.API_KEY_IDENTITY_TYPE;
 
 import org.springframework.stereotype.Service;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import uk.gov.companieshouse.api.util.security.AuthorisationUtil;
 import uk.gov.companieshouse.logging.Logger;
@@ -34,7 +34,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 
 @Service
-public class UserAuthorisationInterceptor extends HandlerInterceptorAdapter {
+public class UserAuthorisationInterceptor implements HandlerInterceptor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
 

--- a/src/main/java/uk/gov/companieshouse/orders/api/model/CertificateItemOptions.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/CertificateItemOptions.java
@@ -32,6 +32,8 @@ public class CertificateItemOptions extends DeliveryItemOptions {
 
     private LiquidatorsDetails liquidatorsDetails;
 
+    private String companyStatus;
+
     public CertificateType getCertificateType() {
         return certificateType;
     }
@@ -151,5 +153,13 @@ public class CertificateItemOptions extends DeliveryItemOptions {
 
     public void setLiquidatorsDetails(LiquidatorsDetails liquidatorsDetails) {
         this.liquidatorsDetails = liquidatorsDetails;
+    }
+
+    public String getCompanyStatus() {
+        return companyStatus;
+    }
+
+    public void setCompanyStatus(String companyStatus) {
+        this.companyStatus = companyStatus;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/OrderControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/OrderControllerIntegrationTest.java
@@ -23,7 +23,6 @@ import uk.gov.companieshouse.orders.api.model.Order;
 import uk.gov.companieshouse.orders.api.model.OrderData;
 import uk.gov.companieshouse.orders.api.repository.CheckoutRepository;
 import uk.gov.companieshouse.orders.api.repository.OrderRepository;
-import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.core.Is.is;
@@ -36,7 +35,6 @@ import static uk.gov.companieshouse.orders.api.model.CertificateType.INCORPORATI
 import static uk.gov.companieshouse.orders.api.util.TestConstants.CERTIFICATE_KIND;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.CERTIFIED_COPY_KIND;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.DOCUMENT;
-import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_ACCESS_TOKEN;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_HEADER_NAME;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_OAUTH2_TYPE_VALUE;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_TYPE_HEADER_NAME;
@@ -55,6 +53,7 @@ class OrderControllerIntegrationTest {
     private static final String ORDER_REFERENCE = "0001";
     private static final String CHECKOUT_ID = "0002";
     private static final String CHECKOUT_REFERENCE = "0002";
+    private static final String COMPANY_STATUS_ACTIVE = "active";
 
     @Autowired
     private MockMvc mockMvc;
@@ -106,6 +105,7 @@ class OrderControllerIntegrationTest {
         certificate.setKind(CERTIFICATE_KIND);
         final CertificateItemOptions options = new CertificateItemOptions();
         options.setCertificateType(INCORPORATION_WITH_ALL_NAME_CHANGES);
+        options.setCompanyStatus(COMPANY_STATUS_ACTIVE);
         certificate.setItemOptions(options);
         orderData.setItems(singletonList(certificate));
         preexistingOrder.setData(orderData);
@@ -119,7 +119,9 @@ class OrderControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.items[0].item_options.certificate_type",
-                        is(INCORPORATION_WITH_ALL_NAME_CHANGES.getJsonName())));
+                        is(INCORPORATION_WITH_ALL_NAME_CHANGES.getJsonName())))
+                .andExpect(jsonPath("$.items[0].item_options.company_status",
+                        is(COMPANY_STATUS_ACTIVE)));
     }
 
     @Test


### PR DESCRIPTION
* Add company_status field to certificate item options.
* Fix compilation warnings caused by use of deprecated classes.
* Fix an issue causing NPEs to be thrown by the MapStruct annotation
  processer when run in IntelliJ.
* Tested locally, working.

Resolves:
[BI-10173](https://companieshouse.atlassian.net/browse/BI-10173)