### PR TITLE
GCI-2003 Rework auth for get checkout endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthenticationInterceptor.java
@@ -59,8 +59,8 @@ public class UserAuthenticationInterceptor implements HandlerInterceptor {
                 return hasSignedInUser(request, response);
             case GET_PAYMENT_DETAILS:
             case GET_ORDER:
-            case GET_CHECKOUT:
                 return hasAuthenticatedClient(request, response);
+            case GET_CHECKOUT:
             case SEARCH:
                 return securityManager.checkIdentity();
             case PATCH_PAYMENT_DETAILS:

--- a/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthorisationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthorisationInterceptor.java
@@ -74,8 +74,9 @@ public class UserAuthorisationInterceptor implements HandlerInterceptor {
             case CHECKOUT_BASKET: case BASKET:
                 return true; // no authorisation required
             case GET_PAYMENT_DETAILS:
-            case GET_CHECKOUT:
                 return getRequestClientIsAuthorised(request, response, this::getCheckoutUserIsResourceOwner);
+            case GET_CHECKOUT:
+                return securityManager.checkPermission() || getRequestClientIsAuthorised(request, response, this::getCheckoutUserIsResourceOwner);
             case GET_ORDER:
                 return getRequestClientIsAuthorised(request, response, this::getOrderUserIsResourceOwner);
             case SEARCH:

--- a/src/test/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthenticationInterceptorTests.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthenticationInterceptorTests.java
@@ -200,8 +200,8 @@ class UserAuthenticationInterceptorTests {
     @Test
     @DisplayName("preHandle accepts get checkout request that has signed in user headers")
     void preHandleAcceptsSignedInUserGetCheckoutRequest() {
-
         // Given
+        when(securityManager.checkIdentity()).thenReturn(true);
         givenRequest(GET, "/checkouts/1234");
         givenRequestHasSignedInUser();
 
@@ -212,8 +212,8 @@ class UserAuthenticationInterceptorTests {
     @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("authenticatedRequestFixtures")
     void preHandleAcceptsAuthenticatedApiRequest(String displayName, String uriPath) {
-
         // Given
+        when(securityManager.checkIdentity()).thenReturn(true);
         givenRequest(GET, uriPath);
         givenRequestHasAuthenticatedApi();
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthorisationInterceptorTests.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthorisationInterceptorTests.java
@@ -18,10 +18,7 @@ import static uk.gov.companieshouse.api.util.security.EricConstants.ERIC_AUTHORI
 import static uk.gov.companieshouse.api.util.security.SecurityConstants.INTERNAL_USER_ROLE;
 import static uk.gov.companieshouse.orders.api.controller.BasketController.CHECKOUT_ID_PATH_VARIABLE;
 import static uk.gov.companieshouse.orders.api.controller.OrderController.ORDER_ID_PATH_VARIABLE;
-import static uk.gov.companieshouse.orders.api.util.EricHeaderHelper.API_KEY_IDENTITY_TYPE;
-import static uk.gov.companieshouse.orders.api.util.EricHeaderHelper.ERIC_IDENTITY;
-import static uk.gov.companieshouse.orders.api.util.EricHeaderHelper.ERIC_IDENTITY_TYPE;
-import static uk.gov.companieshouse.orders.api.util.EricHeaderHelper.OAUTH2_IDENTITY_TYPE;
+import static uk.gov.companieshouse.orders.api.util.EricHeaderHelper.*;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_VALUE;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.WRONG_ERIC_IDENTITY_VALUE;
 
@@ -229,6 +226,18 @@ class UserAuthorisationInterceptorTests {
     }
 
     @Test
+    @DisplayName("preHandle accepts get checkout admin request that has the required headers")
+    void preHandleAcceptsAuthorisedAdminGetCheckoutRequest() {
+        // Given
+        givenRequest(GET, "/checkouts/1234");
+        givenRequestHasSignedInAdminUser(ERIC_IDENTITY_VALUE);
+        givenGetCheckoutIdPathVariableIsPopulated(ERIC_IDENTITY_VALUE);
+
+        // When and then
+        thenRequestIsAccepted();
+    }
+
+    @Test
     @DisplayName("preHandle rejects get order internal API request that lacks the required headers")
     void preHandleRejectsUnauthorisedInternalApiGetOrderRequest() {
 
@@ -317,6 +326,11 @@ class UserAuthorisationInterceptorTests {
     private void givenRequestHasSignedInUser(final String userId) {
         when(request.getHeader(ERIC_IDENTITY_TYPE)).thenReturn(OAUTH2_IDENTITY_TYPE);
         when(request.getHeader(ERIC_IDENTITY)).thenReturn(userId);
+    }
+
+    private void givenRequestHasSignedInAdminUser(final String userId) {
+        this.givenRequestHasSignedInUser(userId);
+        when(request.getHeader(ERIC_AUTHORISED_ROLES)).thenReturn("/admin/chs-order-investigation");
     }
 
     /**


### PR DESCRIPTION
* Use SecurityManager for authenticating/authorising requests to get
  checkout endpoint.