### PR TITLE
GCI-2168 Add enrolled field to BasketData

### DIFF
--- a/src/main/java/uk/gov/companieshouse/orders/api/model/BasketData.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/BasketData.java
@@ -18,6 +18,8 @@ public class BasketData {
 
     private String totalBasketCost;
 
+    private boolean enrolled;
+
 
     public DeliveryDetails getDeliveryDetails() {
         return deliveryDetails;
@@ -65,6 +67,14 @@ public class BasketData {
 
     public void setTotalBasketCost(String totalBasketCost) {
         this.totalBasketCost = totalBasketCost;
+    }
+
+    public boolean isEnrolled() {
+        return enrolled;
+    }
+
+    public void setEnrolled(boolean enrolled) {
+        this.enrolled = enrolled;
     }
 
     @Override


### PR DESCRIPTION
* Field data.enrolled used to determine whether user is enrolled for
  multi-item baskets or not.

Resolves:
[GCI-2168](https://companieshouse.atlassian.net/browse/GCI-2168)