### PR TITLE
GCI-2172 Preserve value of data.enrolled

### DIFF
--- a/src/main/java/uk/gov/companieshouse/orders/api/model/BasketData.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/model/BasketData.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class BasketData {
     private DeliveryDetails deliveryDetails;
@@ -79,4 +80,27 @@ public class BasketData {
 
     @Override
     public String toString() { return new Gson().toJson(this); }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BasketData that = (BasketData) o;
+        return enrolled == that.enrolled
+                && Objects.equals(deliveryDetails, that.deliveryDetails)
+                && Objects.equals(etag, that.etag)
+                && Objects.equals(items, that.items)
+                && Objects.equals(kind, that.kind)
+                && Objects.equals(links, that.links)
+                && Objects.equals(totalBasketCost, that.totalBasketCost);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(deliveryDetails, etag, items, kind, links, totalBasketCost, enrolled);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/repository/BasketRepositoryImpl.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/repository/BasketRepositoryImpl.java
@@ -29,6 +29,7 @@ public class BasketRepositoryImpl implements BasketRepositoryCustom {
         DeliveryDetails deliveryDetails = basketData.getDeliveryDetails();
         BasketData newBasketData = new BasketData();
         newBasketData.setDeliveryDetails(deliveryDetails);
+        newBasketData.setEnrolled(basketData.isEnrolled());
 
         Update update = new Update();
         update.set("data", newBasketData);


### PR DESCRIPTION
* Preserve value of new data.enrolled field across multiple orders.

Resolves:
[GCI-2172](https://companieshouse.atlassian.net/browse/GCI-2172)