### PR TITLE
GCI-2171 Add multi-item support to getBasket endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -47,15 +47,10 @@ import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.stream.Collectors;
 
 import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;

--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -191,7 +191,7 @@ public class BasketController {
     public ResponseEntity<?> getBasket(HttpServletRequest request,
                                        final @RequestHeader(REQUEST_ID_HEADER_NAME) String requestId) {
 
-        Map<String, Object> logMap = new ConcurrentHashMap<>(LoggingUtils.createLogMapWithRequestId(requestId));
+        Map<String, Object> logMap = LoggingUtils.createLogMapWithRequestId(requestId);
         LOGGER.infoRequest(request, "Getting basket", logMap);
 
         final Optional<Basket> retrievedBasket = basketService.getBasketById(EricHeaderHelper.getIdentity(request));

--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -50,7 +50,6 @@ import javax.validation.Valid;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/ItemEnricher.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/ItemEnricher.java
@@ -24,28 +24,28 @@ public class ItemEnricher {
      * For each {@link Item item}, fetch the related item resource using the item's URI and map the returned entity.
      *
      * @param nonEnrichedItems A {@link List list} of non-enriched {@link Item items}.
-     * @param userIdentity The user's identity.
-     * @param logMap A {@link Map map} containing entries to be logged by the logging framework. Fields item_uri and
-     *               company_number will be populated by this method.
+     * @param userIdentity     The user's identity.
+     * @param logMap           A {@link Map map} containing entries to be logged by the logging framework. Fields item_uri and
+     *                         company_number will be populated by this method.
      * @return A {@link List list of} {@link Item items} enriched with data fetched by each item's URI.
      */
     public List<Item> enrichItemsByIdentifiers(List<Item> nonEnrichedItems, String userIdentity, Map<String, Object> logMap) {
-            List<String> processedItemUris = Collections.synchronizedList(new ArrayList<>());
-            List<String> companyNumbers = Collections.synchronizedList(new ArrayList<>());
-            logMap.put(LoggingUtils.ITEM_URI, processedItemUris);
-            logMap.put(LoggingUtils.COMPANY_NUMBER, companyNumbers);
-            return nonEnrichedItems
-                    .parallelStream()
-                    .map(item -> {
-                        String itemUri = item.getItemUri();
-                        try {
-                            Item result = apiClientService.getItem(userIdentity, itemUri);
-                            processedItemUris.add(itemUri);
-                            companyNumbers.add(result.getCompanyNumber());
-                            return result;
-                        } catch (IOException e) {
-                            throw new ItemEnrichmentException("Failed to enrich item: [" + itemUri + "]", e);
-                        }
-                    }).collect(Collectors.toList());
+        List<String> processedItemUris = Collections.synchronizedList(new ArrayList<>());
+        List<String> companyNumbers = Collections.synchronizedList(new ArrayList<>());
+        logMap.put(LoggingUtils.ITEM_URI, processedItemUris);
+        logMap.put(LoggingUtils.COMPANY_NUMBER, companyNumbers);
+        return nonEnrichedItems
+                .stream()
+                .map(item -> {
+                    String itemUri = item.getItemUri();
+                    try {
+                        Item result = apiClientService.getItem(userIdentity, itemUri);
+                        processedItemUris.add(itemUri);
+                        companyNumbers.add(result.getCompanyNumber());
+                        return result;
+                    } catch (IOException e) {
+                        throw new ItemEnrichmentException("Failed to enrich item: [" + itemUri + "]", e);
+                    }
+                }).collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/ItemEnricher.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/ItemEnricher.java
@@ -1,0 +1,51 @@
+package uk.gov.companieshouse.orders.api.service;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.orders.api.logging.LoggingUtils;
+import uk.gov.companieshouse.orders.api.model.Item;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class ItemEnricher {
+
+    private final ApiClientService apiClientService;
+
+    public ItemEnricher(ApiClientService apiClientService) {
+        this.apiClientService = apiClientService;
+    }
+
+    /**
+     * For each {@link Item item}, fetch the related item resource using the item's URI and map the returned entity.
+     *
+     * @param nonEnrichedItems A {@link List list} of non-enriched {@link Item items}.
+     * @param userIdentity The user's identity.
+     * @param logMap A {@link Map map} containing entries to be logged by the logging framework. Fields item_uri and
+     *               company_number will be populated by this method.
+     * @return A {@link List list of} {@link Item items} enriched with data fetched by each item's URI.
+     */
+    public List<Item> enrichItemsByIdentifiers(List<Item> nonEnrichedItems, String userIdentity, Map<String, Object> logMap) {
+            List<String> processedItemUris = Collections.synchronizedList(new ArrayList<>());
+            List<String> companyNumbers = Collections.synchronizedList(new ArrayList<>());
+            logMap.put(LoggingUtils.ITEM_URI, processedItemUris);
+            logMap.put(LoggingUtils.COMPANY_NUMBER, companyNumbers);
+            return nonEnrichedItems
+                    .parallelStream()
+                    .map(item -> {
+                        String itemUri = item.getItemUri();
+                        try {
+                            Item result = apiClientService.getItem(userIdentity, itemUri);
+                            processedItemUris.add(itemUri);
+                            companyNumbers.add(result.getCompanyNumber());
+                            return result;
+                        } catch (IOException e) {
+                            throw new ItemEnrichmentException("Failed to enrich item: [" + itemUri + "]", e);
+                        }
+                    }).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/ItemEnricher.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/ItemEnricher.java
@@ -6,7 +6,6 @@ import uk.gov.companieshouse.orders.api.model.Item;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/ItemEnricher.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/ItemEnricher.java
@@ -30,8 +30,8 @@ public class ItemEnricher {
      * @return A {@link List list of} {@link Item items} enriched with data fetched by each item's URI.
      */
     public List<Item> enrichItemsByIdentifiers(List<Item> nonEnrichedItems, String userIdentity, Map<String, Object> logMap) {
-        List<String> processedItemUris = Collections.synchronizedList(new ArrayList<>());
-        List<String> companyNumbers = Collections.synchronizedList(new ArrayList<>());
+        List<String> processedItemUris = new ArrayList<>();
+        List<String> companyNumbers = new ArrayList<>();
         logMap.put(LoggingUtils.ITEM_URI, processedItemUris);
         logMap.put(LoggingUtils.COMPANY_NUMBER, companyNumbers);
         return nonEnrichedItems

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/ItemEnrichmentException.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/ItemEnrichmentException.java
@@ -1,0 +1,10 @@
+package uk.gov.companieshouse.orders.api.service;
+
+/**
+ * Thrown if an error occurs when attempting to enrich an item with its related item resource.
+ */
+public class ItemEnrichmentException extends RuntimeException {
+    public ItemEnrichmentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/ItemEnricherTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/ItemEnricherTest.java
@@ -1,0 +1,104 @@
+package uk.gov.companieshouse.orders.api.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.orders.api.logging.LoggingUtils;
+import uk.gov.companieshouse.orders.api.model.Item;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ItemEnricherTest {
+
+    private static final String PATH_TO_CERTIFICATE = "/path/to/certificate";
+    private static final String PATH_TO_DOCUMENT = "/path/to/document";
+    private static final String PATH_TO_MISSING_IMAGE = "/path/to/missingImage";
+    private static final String COMPANY_NUMBER_CERTIFICATE = "00000001";
+    private static final String COMPANY_NUMBER_DOCUMENT = "00000002";
+    private static final String COMPANY_NUMBER_MISSING_IMAGE = "00000003";
+    private static final String USER_ID = "user_id";
+
+    @InjectMocks
+    private ItemEnricher executionEngine;
+
+    @Mock
+    private ApiClientService apiClientService;
+
+    @Mock
+    private Item certificate;
+
+    @Mock
+    private Item document;
+
+    @Mock
+    private Item missingImage;
+
+    @Test
+    void testEnrichBasketItemsEnrichesItemsWithResourceData() throws IOException {
+        // given
+        when(certificate.getItemUri()).thenReturn(PATH_TO_CERTIFICATE);
+        when(document.getItemUri()).thenReturn(PATH_TO_DOCUMENT);
+        when(missingImage.getItemUri()).thenReturn(PATH_TO_MISSING_IMAGE);
+        when(certificate.getCompanyNumber()).thenReturn(COMPANY_NUMBER_CERTIFICATE);
+        when(document.getCompanyNumber()).thenReturn(COMPANY_NUMBER_DOCUMENT);
+        when(missingImage.getCompanyNumber()).thenReturn(COMPANY_NUMBER_MISSING_IMAGE);
+        when(apiClientService.getItem(any(), eq(PATH_TO_CERTIFICATE))).thenReturn(certificate);
+        when(apiClientService.getItem(any(), eq(PATH_TO_DOCUMENT))).thenReturn(document);
+        when(apiClientService.getItem(any(), eq(PATH_TO_MISSING_IMAGE))).thenReturn(missingImage);
+        Map<String, Object> logMap = new HashMap<>();
+
+        // when
+        List<Item> result = executionEngine.enrichItemsByIdentifiers(Arrays.asList(certificate, document, missingImage), USER_ID, logMap);
+
+        // then
+        assertEquals(Arrays.asList(certificate, document, missingImage), result);
+        assertTrue(logMap.containsKey(LoggingUtils.ITEM_URI));
+        assertTrue(logMap.containsKey(LoggingUtils.COMPANY_NUMBER));
+        verify(apiClientService).getItem(USER_ID, PATH_TO_CERTIFICATE);
+        verify(apiClientService).getItem(USER_ID, PATH_TO_DOCUMENT);
+        verify(apiClientService).getItem(USER_ID, PATH_TO_MISSING_IMAGE);
+    }
+
+    @Test
+    @DisplayName("Fetch basket containing multiple items returns HTTP 400 Bad Request if exception thrown handling item")
+    void fetchBasketWithMultipleItemsReturnsBadRequest() throws Exception {
+        // given
+        when(certificate.getItemUri()).thenReturn(PATH_TO_CERTIFICATE);
+        when(document.getItemUri()).thenReturn(PATH_TO_DOCUMENT);
+        when(missingImage.getItemUri()).thenReturn(PATH_TO_MISSING_IMAGE);
+        when(certificate.getCompanyNumber()).thenReturn(COMPANY_NUMBER_CERTIFICATE);
+        when(document.getCompanyNumber()).thenReturn(COMPANY_NUMBER_DOCUMENT);
+        when(apiClientService.getItem(any(), eq(PATH_TO_CERTIFICATE))).thenReturn(certificate);
+        when(apiClientService.getItem(any(), eq(PATH_TO_DOCUMENT))).thenReturn(document);
+        when(apiClientService.getItem(any(), eq(PATH_TO_MISSING_IMAGE))).thenThrow(ApiErrorResponseException.class);
+        Map<String, Object> logMap = new HashMap<>();
+
+        // when
+        Executable executable = () -> executionEngine.enrichItemsByIdentifiers(Arrays.asList(certificate, document, missingImage), USER_ID, logMap);
+
+        // then
+        ItemEnrichmentException enrichmentException = assertThrows(ItemEnrichmentException.class, executable);
+        assertEquals("Failed to enrich item: [" + PATH_TO_MISSING_IMAGE + "]", enrichmentException.getMessage());
+        verify(apiClientService).getItem(USER_ID, PATH_TO_CERTIFICATE);
+        verify(apiClientService).getItem(USER_ID, PATH_TO_DOCUMENT);
+        verify(apiClientService).getItem(USER_ID, PATH_TO_MISSING_IMAGE);
+    }
+}


### PR DESCRIPTION
* Add support for baskets containing multiple items to getBasket
  endpoint in BasketController.
* Related item resources will be fetched by URI in parallel and mapped
  to the corresponding item model.