### PR TITLE
GCI-2209 Multi-item support for CheckoutBasket endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -33,7 +32,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.model.payment.PaymentApi;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -598,22 +596,5 @@ public class BasketController {
         }
 
         return total;
-    }
-
-    private Item getItemFromApiClient(String itemUri, String passthroughHeader, Map<String,
-            Object> logMap) throws IOException {
-        Item item = apiClientService.getItem(passthroughHeader, itemUri);
-        if (item != null) {
-            LoggingUtils.logIfNotNull(logMap, LoggingUtils.COMPANY_NUMBER, item.getCompanyNumber());
-        }
-        return item;
-    }
-
-    private void logItemError(HttpServletRequest request, Map<String, Object> logMap,
-            String itemUri, Exception exception) {
-        logMap.put(LoggingUtils.STATUS, BAD_REQUEST);
-        logMap.put(LoggingUtils.EXCEPTION, exception);
-        LOGGER.errorRequest(request, String.format("Failed to retrieve item "
-                + "from api client for item uri: %s", itemUri), logMap);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -368,11 +368,7 @@ public class BasketController {
         }
 
         List<String> itemUriList = retrievedBasket.getData().getItems().stream()
-                .map(i -> {
-                    String itemUri = i.getItemUri();
-                    LoggingUtils.logIfNotNull(logMap, LoggingUtils.ITEM_URI, itemUri);
-                    return itemUri;
-                }).collect(Collectors.toList());
+                .map(Item::getItemUri).collect(Collectors.toList());
 
         List<Item> itemsList = new ArrayList<>();
         for (String itemUri : itemUriList) {

--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -373,21 +373,29 @@ public class BasketController {
         if (itemUriList.size() == 1) {
             String itemUri = itemUriList.get(0);
             try {
+                LOGGER.info(String.format("Attempting to retrieve item with uri: %s "
+                        + "from api client", itemUri), logMap);
                 itemsList.add(getItemFromApiClient(itemUri, passthroughHeader, logMap));
             } catch (Exception exception) {
                 logItemError(request, logMap, itemUri, exception);
                 return ResponseEntity.status(BAD_REQUEST).body(new ApiError(BAD_REQUEST,
                         "Failed to retrieve item"));
             }
+            LOGGER.info(String.format("Retrieved item with uri: %s "
+                    + "from api client", itemUri), logMap);
         } else {
             itemsList.addAll(itemUriList.stream()
                 .map(itemUri -> {
                     Item item = null;
                     try {
+                        LOGGER.info(String.format("Attempting to retrieve item with uri: %s "
+                                + "from api client", itemUri), logMap);
                         item = getItemFromApiClient(itemUri, passthroughHeader, logMap);
                     } catch (IOException exception) {
                         logItemError(request, logMap, itemUri, exception);
                     }
+                    LOGGER.info(String.format("Retrieved item with uri: %s "
+                            + "from api client", itemUri), logMap);
                     return item;
                 }).filter(Objects::nonNull).collect(Collectors.toList()));
         }
@@ -609,6 +617,6 @@ public class BasketController {
         logMap.put(LoggingUtils.STATUS, BAD_REQUEST);
         logMap.put(LoggingUtils.EXCEPTION, exception);
         LOGGER.errorRequest(request, String.format("Failed to retrieve item "
-                + "from api client for item uri: %s", itemUri, logMap));
+                + "from api client for item uri: %s", itemUri), logMap);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapper.java
@@ -25,34 +25,30 @@ public interface CheckoutToPaymentDetailsMapper {
 
     default void updateDTOWithPaymentDetails(CheckoutData checkoutData, PaymentDetailsDTO paymentDetailsDTO) {
         List<ItemDTO> itemDTOs = new ArrayList<>();
-        List<Item> itemsList = checkoutData.getItems();
-        itemsList.stream().forEach(
-            item -> {
-                for (ItemCosts itemCosts : item.getItemCosts()) {
-                        ItemDTO itemDTO = new ItemDTO();
-                        List<String> classOfPayment = new ArrayList<>();
-                        classOfPayment.add("orderable-item");
-                        itemDTO.setClassOfPayment(classOfPayment);
+        for (Item item : checkoutData.getItems()) {
+            for (ItemCosts itemCosts : item.getItemCosts()) {
+                ItemDTO itemDTO = new ItemDTO();
+                List<String> classOfPayment = new ArrayList<>();
+                classOfPayment.add("orderable-item");
+                itemDTO.setClassOfPayment(classOfPayment);
 
-                        List<String> availablePaymentMethods = new ArrayList<>();
-                        availablePaymentMethods.add("credit-card");
-                        itemDTO.setAvailablePaymentMethods(availablePaymentMethods);
+                List<String> availablePaymentMethods = new ArrayList<>();
+                availablePaymentMethods.add("credit-card");
+                itemDTO.setAvailablePaymentMethods(availablePaymentMethods);
 
-                        itemDTO.setResourceKind(item.getKind());
-                        itemDTO.setKind("cost#cost");
+                itemDTO.setResourceKind(item.getKind());
+                itemDTO.setKind("cost#cost");
 
-                        itemDTO.setProductType(itemCosts.getProductType().getJsonName());
-                        itemDTO.setAmount(itemCosts.getCalculatedCost());
+                itemDTO.setProductType(itemCosts.getProductType().getJsonName());
+                itemDTO.setAmount(itemCosts.getCalculatedCost());
 
-                        itemDTO.setDescriptionIdentifier(item.getDescriptionIdentifier());
-                        itemDTO.setDescriptionValues(item.getDescriptionValues());
+                itemDTO.setDescriptionIdentifier(item.getDescriptionIdentifier());
+                itemDTO.setDescriptionValues(item.getDescriptionValues());
 
-                        itemDTO.setDescription(item.getDescription());
-                        itemDTOs.add(itemDTO);
-                }
+                itemDTO.setDescription(item.getDescription());
+                itemDTOs.add(itemDTO);
             }
-        );
-
+        }
         paymentDetailsDTO.setItems(itemDTOs);
         paymentDetailsDTO.setKind("payment-details#payment-details");
     }

--- a/src/main/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapper.java
@@ -25,34 +25,35 @@ public interface CheckoutToPaymentDetailsMapper {
 
     default void updateDTOWithPaymentDetails(CheckoutData checkoutData, PaymentDetailsDTO paymentDetailsDTO) {
         List<ItemDTO> itemDTOs = new ArrayList<>();
-        Item item = checkoutData.getItems().get(0);
-        for (ItemCosts itemCosts : item.getItemCosts()) {
-            ItemDTO itemDTO = new ItemDTO();
+        List<Item> itemsList = checkoutData.getItems();
+        itemsList.stream().forEach(
+            item -> {
+                for (ItemCosts itemCosts : item.getItemCosts()) {
+                        ItemDTO itemDTO = new ItemDTO();
+                        List<String> classOfPayment = new ArrayList<>();
+                        classOfPayment.add("orderable-item");
+                        itemDTO.setClassOfPayment(classOfPayment);
 
-            List<String> classOfPayment = new ArrayList<>();
-            classOfPayment.add("orderable-item");
-            itemDTO.setClassOfPayment(classOfPayment);
+                        List<String> availablePaymentMethods = new ArrayList<>();
+                        availablePaymentMethods.add("credit-card");
+                        itemDTO.setAvailablePaymentMethods(availablePaymentMethods);
 
-            List<String> availablePaymentMethods = new ArrayList<>();
-            availablePaymentMethods.add("credit-card");
-            itemDTO.setAvailablePaymentMethods(availablePaymentMethods);
+                        itemDTO.setResourceKind(item.getKind());
+                        itemDTO.setKind("cost#cost");
 
-            itemDTO.setResourceKind(item.getKind());
-            itemDTO.setKind("cost#cost");
+                        itemDTO.setProductType(itemCosts.getProductType().getJsonName());
+                        itemDTO.setAmount(itemCosts.getCalculatedCost());
 
-            itemDTO.setProductType(itemCosts.getProductType().getJsonName());
-            itemDTO.setAmount(itemCosts.getCalculatedCost());
+                        itemDTO.setDescriptionIdentifier(item.getDescriptionIdentifier());
+                        itemDTO.setDescriptionValues(item.getDescriptionValues());
 
-            itemDTO.setDescriptionIdentifier(item.getDescriptionIdentifier());
-            itemDTO.setDescriptionValues(item.getDescriptionValues());
-
-            itemDTO.setDescription(item.getDescription());
-
-            itemDTOs.add(itemDTO);
-        }
+                        itemDTO.setDescription(item.getDescription());
+                        itemDTOs.add(itemDTO);
+                }
+            }
+        );
 
         paymentDetailsDTO.setItems(itemDTOs);
         paymentDetailsDTO.setKind("payment-details#payment-details");
-        paymentDetailsDTO.setCompanyNumber(item.getCompanyNumber());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/CheckoutService.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/CheckoutService.java
@@ -47,7 +47,8 @@ public class CheckoutService {
         return "ORD-" + String.join("-", tranId);
     }
 
-    public Checkout createCheckout(Item item, String userId, String email, DeliveryDetails deliveryDetails) {
+    public Checkout createCheckout(List<Item> itemsList, String userId, String email,
+            DeliveryDetails deliveryDetails) {
         final LocalDateTime now = LocalDateTime.now();
         String checkoutId = autoGenerateId();
 
@@ -64,7 +65,7 @@ public class CheckoutService {
         checkout.getData().setStatus(PaymentStatus.PENDING);
         checkout.getData().setEtag(etagGeneratorService.generateEtag());
         checkout.getData().setLinks(linksGeneratorService.generateCheckoutLinks(checkoutId));
-        checkout.getData().getItems().add(item);
+        checkout.getData().getItems().addAll(itemsList);
         checkout.getData().setReference(checkoutId);
         checkout.getData().setKind("order");
         checkout.getData().setDeliveryDetails(deliveryDetails);

--- a/src/main/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidator.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidator.java
@@ -41,8 +41,9 @@ public class CheckoutBasketValidator {
                     LoggingUtils.logIfNotNull(logMap, LoggingUtils.ITEM_URI, itemUri);
                     Item retrievedItem = apiClientService.getItem(passthroughHeader, itemUri);
 
-                    if (retrievedItem.isPostalDelivery() && !deliveryDetailsValidator
-                            .isValid(basket.getData().getDeliveryDetails())) {
+                    if (Boolean.TRUE.equals(retrievedItem.isPostalDelivery())
+                            && !deliveryDetailsValidator.isValid(
+                                    basket.getData().getDeliveryDetails())) {
                         logMap.put(LoggingUtils.ERROR_TYPE,
                                 ErrorType.DELIVERY_DETAILS_MISSING.getValue());
                         LOGGER.error(ErrorType.DELIVERY_DETAILS_MISSING.getValue(), logMap);

--- a/src/main/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidator.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidator.java
@@ -35,25 +35,32 @@ public class CheckoutBasketValidator {
             errors.add(ErrorType.BASKET_ITEMS_MISSING.getValue());
         }
         else {
-            String itemUri = "";
-            try {
-                Item item = basketItems.get(0);
-                itemUri = item.getItemUri();
-                LoggingUtils.logIfNotNull(logMap, LoggingUtils.ITEM_URI, itemUri);
+            int basketCount = basketItems.size();
+            basketItems.stream().forEach(
+                item -> {
+                    try {
+                        String itemUri = item.getItemUri();
+                        LoggingUtils.logIfNotNull(logMap, LoggingUtils.ITEM_URI, itemUri);
+                        Item retrievedItem = apiClientService.getItem(passthroughHeader, itemUri);
 
-                item = apiClientService.getItem(passthroughHeader, itemUri);
-
-                if (item.isPostalDelivery() && !deliveryDetailsValidator.isValid(basket.getData().getDeliveryDetails())) {
-                    logMap.put(LoggingUtils.ERROR_TYPE, ErrorType.DELIVERY_DETAILS_MISSING.getValue());
-                    LOGGER.error(ErrorType.DELIVERY_DETAILS_MISSING.getValue(), logMap);
-                    errors.add(ErrorType.DELIVERY_DETAILS_MISSING.getValue());
+                        if (retrievedItem.isPostalDelivery() && !deliveryDetailsValidator
+                                .isValid(basket.getData().getDeliveryDetails())) {
+                            logMap.put(LoggingUtils.ERROR_TYPE,
+                                    ErrorType.DELIVERY_DETAILS_MISSING.getValue());
+                            LOGGER.error(ErrorType.DELIVERY_DETAILS_MISSING.getValue(), logMap);
+                            errors.add(ErrorType.DELIVERY_DETAILS_MISSING.getValue());
+                        }
+                    } catch (Exception exception) {
+                        logMap.put(LoggingUtils.EXCEPTION, exception);
+                        logMap.put(LoggingUtils.ERROR_TYPE,
+                                ErrorType.BASKET_ITEM_INVALID.getValue());
+                        LOGGER.error("Failed to get item for item uri: %s", logMap);
+                        if (basketCount == 1) {
+                            errors.add(ErrorType.BASKET_ITEM_INVALID.getValue());
+                        }
+                    }
                 }
-            } catch (Exception exception) {
-                logMap.put(LoggingUtils.EXCEPTION, exception);
-                logMap.put(LoggingUtils.ERROR_TYPE, ErrorType.BASKET_ITEM_INVALID.getValue());
-                LOGGER.error("Failed to get item", logMap);
-                errors.add(ErrorType.BASKET_ITEM_INVALID.getValue());
-            }
+            );
         }
         return errors;
     }

--- a/src/main/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidator.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidator.java
@@ -35,32 +35,27 @@ public class CheckoutBasketValidator {
             errors.add(ErrorType.BASKET_ITEMS_MISSING.getValue());
         }
         else {
-            int basketCount = basketItems.size();
-            basketItems.stream().forEach(
-                item -> {
-                    try {
-                        String itemUri = item.getItemUri();
-                        LoggingUtils.logIfNotNull(logMap, LoggingUtils.ITEM_URI, itemUri);
-                        Item retrievedItem = apiClientService.getItem(passthroughHeader, itemUri);
+            for (Item item : basketItems) {
+                try {
+                    String itemUri = item.getItemUri();
+                    LoggingUtils.logIfNotNull(logMap, LoggingUtils.ITEM_URI, itemUri);
+                    Item retrievedItem = apiClientService.getItem(passthroughHeader, itemUri);
 
-                        if (retrievedItem.isPostalDelivery() && !deliveryDetailsValidator
-                                .isValid(basket.getData().getDeliveryDetails())) {
-                            logMap.put(LoggingUtils.ERROR_TYPE,
-                                    ErrorType.DELIVERY_DETAILS_MISSING.getValue());
-                            LOGGER.error(ErrorType.DELIVERY_DETAILS_MISSING.getValue(), logMap);
-                            errors.add(ErrorType.DELIVERY_DETAILS_MISSING.getValue());
-                        }
-                    } catch (Exception exception) {
-                        logMap.put(LoggingUtils.EXCEPTION, exception);
+                    if (retrievedItem.isPostalDelivery() && !deliveryDetailsValidator
+                            .isValid(basket.getData().getDeliveryDetails())) {
                         logMap.put(LoggingUtils.ERROR_TYPE,
-                                ErrorType.BASKET_ITEM_INVALID.getValue());
-                        LOGGER.error("Failed to get item for item uri: %s", logMap);
-                        if (basketCount == 1) {
-                            errors.add(ErrorType.BASKET_ITEM_INVALID.getValue());
-                        }
+                                ErrorType.DELIVERY_DETAILS_MISSING.getValue());
+                        LOGGER.error(ErrorType.DELIVERY_DETAILS_MISSING.getValue(), logMap);
+                        errors.add(ErrorType.DELIVERY_DETAILS_MISSING.getValue());
                     }
+                } catch (Exception exception) {
+                    logMap.put(LoggingUtils.EXCEPTION, exception);
+                    logMap.put(LoggingUtils.ERROR_TYPE,
+                            ErrorType.BASKET_ITEM_INVALID.getValue());
+                    LOGGER.error(ErrorType.BASKET_ITEM_INVALID.getValue(), logMap);
+                    errors.add(ErrorType.BASKET_ITEM_INVALID.getValue());
                 }
-            );
+            }
         }
         return errors;
     }

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -158,10 +158,8 @@ class BasketControllerIntegrationTest {
 
     private static final String EXPECTED_TOTAL_ORDER_COST = "15";
     private static final String EXPECTED_TOTAL_ORDER_COST_MULTIPLE = "33";
-    private static final String EXPECTED_TOTAL_ORDER_COST_MULTIPLE_NO_MID = "30";
     private static final int EXPECTED_CHECKOUT_ITEMS_SIZE = 3;
-    private static final int EXPECTED_CHECKOUT_ITEMS_SIZE_NO_MID = 2;
-    private static final String DISCOUNT_APPLIED_1 = "0";
+        private static final String DISCOUNT_APPLIED_1 = "0";
     private static final String ITEM_COST_1 = "5";
     private static final String CALCULATED_COST_1 = "5";
     private static final String DISCOUNT_APPLIED_2 = "10";

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -119,6 +119,7 @@ import uk.gov.companieshouse.orders.api.service.ApiClientService;
 import uk.gov.companieshouse.orders.api.service.CheckoutService;
 import uk.gov.companieshouse.orders.api.service.EtagGeneratorService;
 import uk.gov.companieshouse.orders.api.util.TimestampedEntityVerifier;
+import uk.gov.companieshouse.orders.api.validator.CheckoutBasketValidator;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 @DirtiesContext
@@ -156,6 +157,10 @@ class BasketControllerIntegrationTest {
     private static final LocalDateTime SATISFIED_AT = LocalDateTime.of(2020, Month.JANUARY, 1, 0, 0);
 
     private static final String EXPECTED_TOTAL_ORDER_COST = "15";
+    private static final String EXPECTED_TOTAL_ORDER_COST_MULTIPLE = "33";
+    private static final String EXPECTED_TOTAL_ORDER_COST_MULTIPLE_NO_MID = "30";
+    private static final int EXPECTED_CHECKOUT_ITEMS_SIZE = 3;
+    private static final int EXPECTED_CHECKOUT_ITEMS_SIZE_NO_MID = 2;
     private static final String DISCOUNT_APPLIED_1 = "0";
     private static final String ITEM_COST_1 = "5";
     private static final String CALCULATED_COST_1 = "5";
@@ -256,6 +261,9 @@ class BasketControllerIntegrationTest {
 
     @Mock
     private ApiErrorResponseException apiErrorResponseException;
+
+    @Mock
+    private CheckoutBasketValidator checkoutBasketValidator;
 
     @BeforeEach
     void setUp() {
@@ -687,6 +695,138 @@ class BasketControllerIntegrationTest {
         assertEquals(FORENAME, retrievedOptions.getForename());
         assertEquals(SURNAME, retrievedOptions.getSurname());
         assertEquals(EXPECTED_TOTAL_ORDER_COST, checkoutData.getTotalOrderCost());
+    }
+
+    @Test
+    @DisplayName("Checkout basket creates checkout with correctly with multiple items")
+    void checkoutBasketWithMultipleItems () throws Exception {
+        final LocalDateTime start = timestamps.start();
+        final Basket basket = createBasket(start, VALID_CERTIFIED_COPY_URI);
+        Item certificateItem = new Item();
+        certificateItem.setItemUri(VALID_CERTIFICATE_URI);
+        basket.getData().getItems().add(certificateItem);
+        Item missingImageItem = new Item();
+        missingImageItem.setItemUri(VALID_MISSING_IMAGE_DELIVERY_URI);
+        basket.getData().getItems().add(missingImageItem);
+
+        basketRepository.save(basket);
+
+        final CertifiedCopy copy = new CertifiedCopy();
+        copy.setKind(CERTIFIED_COPY_KIND);
+        final CertifiedCopyItemOptions documentOptions = new CertifiedCopyItemOptions();
+        documentOptions.setFilingHistoryDocuments(singletonList(DOCUMENT));
+        copy.setItemOptions(documentOptions);
+        copy.setItemCosts(createItemCosts());
+        copy.setPostageCost(POSTAGE_COST);
+        copy.setPostalDelivery(false);
+        when(apiClientService.getItem(ERIC_ACCESS_TOKEN, VALID_CERTIFIED_COPY_URI)).thenReturn(copy);
+
+        final Certificate certificate = new Certificate();
+        certificate.setKind(CERTIFICATE_KIND);
+        final CertificateItemOptions options = new CertificateItemOptions();
+        options.setCertificateType(INCORPORATION_WITH_ALL_NAME_CHANGES);
+        certificate.setItemOptions(options);
+        certificate.setItemCosts(createItemCosts());
+        certificate.setPostageCost(POSTAGE_COST);
+        certificate.setPostalDelivery(false);
+        when(apiClientService.getItem(ERIC_ACCESS_TOKEN, VALID_CERTIFICATE_URI)).thenReturn(certificate);
+
+        final MissingImageDelivery missingImageDelivery = new MissingImageDelivery();
+        missingImageDelivery.setKind(MISSING_IMAGE_DELIVERY_KIND);
+        missingImageDelivery.setItemOptions(MISSING_IMAGE_DELIVERY_ITEM_OPTIONS);
+        missingImageDelivery.setItemCosts(MISSING_IMAGE_DELIVERY_COSTS);
+        missingImageDelivery.setPostageCost(POSTAGE_COST);
+        missingImageDelivery.setPostalDelivery(false);
+        missingImageDelivery.setTotalItemCost(MID_TOTAL_ITEM_COST);
+        missingImageDelivery.setKind(MISSING_IMAGE_DELIVERY_KIND);
+
+        when(apiClientService.getItem(ERIC_ACCESS_TOKEN, VALID_MISSING_IMAGE_DELIVERY_URI)).thenReturn(missingImageDelivery);
+
+        ResultActions resultActions = mockMvc.perform(post("/basket/checkouts")
+                .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
+                .header(ERIC_IDENTITY_TYPE_HEADER_NAME, ERIC_IDENTITY_OAUTH2_TYPE_VALUE)
+                .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
+                .header(ERIC_AUTHORISED_USER_HEADER_NAME, ERIC_AUTHORISED_USER_VALUE)
+                .header(ERIC_AUTHORISED_TOKEN_PERMISSIONS, String.format(TOKEN_PERMISSION_VALUE, Permission.Value.CREATE))
+                .header(ApiSdkManager.getEricPassthroughTokenHeader(), ERIC_ACCESS_TOKEN))
+                .andExpect(status().isAccepted());
+
+        MvcResult result = resultActions.andReturn();
+        MockHttpServletResponse response = result.getResponse();
+        assertThat(response.getHeader(PAYMENT_REQUIRED_HEADER), is(COSTS_LINK));
+        String contentAsString = response.getContentAsString();
+        CheckoutData responseCheckoutData = mapper.readValue(contentAsString, CheckoutData.class);
+
+        final Optional<Checkout> retrievedCheckout = checkoutRepository.findById(responseCheckoutData.getReference());
+        assertTrue(retrievedCheckout.isPresent());
+        assertEquals(ERIC_IDENTITY_VALUE, retrievedCheckout.get().getUserId());
+        final CheckoutData checkoutData = retrievedCheckout.get().getData();
+        assertEquals(EXPECTED_TOTAL_ORDER_COST_MULTIPLE, checkoutData.getTotalOrderCost());
+        assertEquals(CERTIFIED_COPY_KIND, checkoutData.getItems().get(0).getKind());
+        assertEquals(CERTIFICATE_KIND, checkoutData.getItems().get(1).getKind());
+        assertEquals(MISSING_IMAGE_DELIVERY_KIND, checkoutData.getItems().get(2).getKind());
+        assertEquals(EXPECTED_CHECKOUT_ITEMS_SIZE, checkoutData.getItems().size());
+    }
+
+    @Test
+    @DisplayName("Checkout basket creates checkout when one item errors")
+    void checkoutBasketWithErrorOnMultipleItems () throws Exception {
+        final LocalDateTime start = timestamps.start();
+        final Basket basket = createBasket(start, VALID_CERTIFIED_COPY_URI);
+        Item certificateItem = new Item();
+        certificateItem.setItemUri(VALID_CERTIFICATE_URI);
+        basket.getData().getItems().add(certificateItem);
+        Item missingImageItem = new Item();
+        missingImageItem.setItemUri(VALID_MISSING_IMAGE_DELIVERY_URI);
+        basket.getData().getItems().add(missingImageItem);
+
+        basketRepository.save(basket);
+
+        final CertifiedCopy copy = new CertifiedCopy();
+        copy.setKind(CERTIFIED_COPY_KIND);
+        final CertifiedCopyItemOptions documentOptions = new CertifiedCopyItemOptions();
+        documentOptions.setFilingHistoryDocuments(singletonList(DOCUMENT));
+        copy.setItemOptions(documentOptions);
+        copy.setItemCosts(createItemCosts());
+        copy.setPostageCost(POSTAGE_COST);
+        copy.setPostalDelivery(false);
+        when(apiClientService.getItem(ERIC_ACCESS_TOKEN, VALID_CERTIFIED_COPY_URI)).thenReturn(copy);
+
+        final Certificate certificate = new Certificate();
+        certificate.setKind(CERTIFICATE_KIND);
+        final CertificateItemOptions options = new CertificateItemOptions();
+        options.setCertificateType(INCORPORATION_WITH_ALL_NAME_CHANGES);
+        certificate.setItemOptions(options);
+        certificate.setItemCosts(createItemCosts());
+        certificate.setPostageCost(POSTAGE_COST);
+        certificate.setPostalDelivery(false);
+        when(apiClientService.getItem(ERIC_ACCESS_TOKEN, VALID_CERTIFICATE_URI)).thenReturn(certificate);
+
+        when(apiClientService.getItem(ERIC_ACCESS_TOKEN, VALID_MISSING_IMAGE_DELIVERY_URI)).thenThrow(apiErrorResponseException);
+
+        ResultActions resultActions = mockMvc.perform(post("/basket/checkouts")
+                .header(REQUEST_ID_HEADER_NAME, TOKEN_REQUEST_ID_VALUE)
+                .header(ERIC_IDENTITY_TYPE_HEADER_NAME, ERIC_IDENTITY_OAUTH2_TYPE_VALUE)
+                .header(ERIC_IDENTITY_HEADER_NAME, ERIC_IDENTITY_VALUE)
+                .header(ERIC_AUTHORISED_USER_HEADER_NAME, ERIC_AUTHORISED_USER_VALUE)
+                .header(ERIC_AUTHORISED_TOKEN_PERMISSIONS, String.format(TOKEN_PERMISSION_VALUE, Permission.Value.CREATE))
+                .header(ApiSdkManager.getEricPassthroughTokenHeader(), ERIC_ACCESS_TOKEN))
+                .andExpect(status().isAccepted());
+
+        MvcResult result = resultActions.andReturn();
+        MockHttpServletResponse response = result.getResponse();
+        assertThat(response.getHeader(PAYMENT_REQUIRED_HEADER), is(COSTS_LINK));
+        String contentAsString = response.getContentAsString();
+        CheckoutData responseCheckoutData = mapper.readValue(contentAsString, CheckoutData.class);
+
+        final Optional<Checkout> retrievedCheckout = checkoutRepository.findById(responseCheckoutData.getReference());
+        assertTrue(retrievedCheckout.isPresent());
+        assertEquals(ERIC_IDENTITY_VALUE, retrievedCheckout.get().getUserId());
+        final CheckoutData checkoutData = retrievedCheckout.get().getData();
+        assertEquals(EXPECTED_TOTAL_ORDER_COST_MULTIPLE_NO_MID, checkoutData.getTotalOrderCost());
+        assertEquals(CERTIFIED_COPY_KIND, checkoutData.getItems().get(0).getKind());
+        assertEquals(CERTIFICATE_KIND, checkoutData.getItems().get(1).getKind());
+        assertEquals(EXPECTED_CHECKOUT_ITEMS_SIZE_NO_MID, checkoutData.getItems().size());
     }
 
     @Test
@@ -1905,7 +2045,6 @@ class BasketControllerIntegrationTest {
                 .andExpect(jsonPath("$.payment_reference", is(checkout.getId())))
                 .andExpect(jsonPath("$.kind", is("payment-details#payment-details")))
                 .andExpect(jsonPath("$.status", is("paid")))
-                .andExpect(jsonPath("$.company_number", is(COMPANY_NUMBER)))
                 .andExpect(jsonPath("$.paid_at", is(paymentsApiParsableDateTime(PAID_AT_DATE))))
                 .andExpect(jsonPath("$.links.self", is(mapper.convertValue(paymentLinksDTO.getSelf(), String.class))))
                 .andExpect(jsonPath("$.links.resource", is(mapper.convertValue(paymentLinksDTO.getResource(), String.class))))
@@ -2277,8 +2416,6 @@ class BasketControllerIntegrationTest {
         itemDTO3.setProductType("certificate-additional-copy");
         itemDTOs.add(itemDTO3);
         paymentDetailsDTO.setItems(itemDTOs);
-
-        paymentDetailsDTO.setCompanyNumber(COMPANY_NUMBER);
 
         return paymentDetailsDTO;
     }

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -2091,7 +2091,8 @@ class BasketControllerIntegrationTest {
         copy.setItemOptions(options);
 
         return checkoutService.createCheckout(
-                copy, ERIC_IDENTITY_VALUE, ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
+                Collections.singletonList(copy), ERIC_IDENTITY_VALUE, ERIC_AUTHORISED_USER_VALUE,
+                new DeliveryDetails());
     }
 
     private Checkout createCertificateCheckout() {
@@ -2106,7 +2107,9 @@ class BasketControllerIntegrationTest {
         certificate.setItemOptions(options);
 
         return checkoutService.createCheckout(
-                certificate, ERIC_IDENTITY_VALUE, ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
+                Collections.singletonList(certificate), ERIC_IDENTITY_VALUE,
+                ERIC_AUTHORISED_USER_VALUE,
+                new DeliveryDetails());
     }
 
     private Checkout createMissingImageCheckout() {
@@ -2119,7 +2122,8 @@ class BasketControllerIntegrationTest {
         missingImageDelivery.setItemOptions(MISSING_IMAGE_DELIVERY_ITEM_OPTIONS);
 
         return checkoutService.createCheckout(
-                missingImageDelivery, ERIC_IDENTITY_VALUE, ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
+                Collections.singletonList(missingImageDelivery), ERIC_IDENTITY_VALUE,
+                ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.orders.api.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -8,12 +9,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.ACCEPTED;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.OK;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_HEADER_NAME;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_VALUE;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.REQUEST_ID_HEADER_NAME;
 
 import java.io.IOException;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,6 +30,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -35,6 +41,7 @@ import uk.gov.companieshouse.api.model.payment.PaymentApi;
 import uk.gov.companieshouse.orders.api.dto.BasketItemDTO;
 import uk.gov.companieshouse.orders.api.dto.BasketPaymentRequestDTO;
 import uk.gov.companieshouse.orders.api.dto.BasketRequestDTO;
+import uk.gov.companieshouse.orders.api.exception.ConflictException;
 import uk.gov.companieshouse.orders.api.exception.ErrorType;
 import uk.gov.companieshouse.orders.api.mapper.BasketMapper;
 import uk.gov.companieshouse.orders.api.mapper.ItemMapper;
@@ -54,6 +61,7 @@ import uk.gov.companieshouse.orders.api.service.ItemEnrichmentException;
 import uk.gov.companieshouse.orders.api.service.OrderService;
 import uk.gov.companieshouse.orders.api.util.EricHeaderHelper;
 import uk.gov.companieshouse.orders.api.util.TimestampedEntityVerifier;
+import uk.gov.companieshouse.orders.api.validator.CheckoutBasketValidator;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 /**
@@ -111,6 +119,9 @@ class BasketControllerTest {
 
     @Mock
     private BasketItemDTO basketResponse;
+
+    @Mock
+    private CheckoutBasketValidator checkoutBasketValidator;
 
     @Test
     @DisplayName("Fetch basket containing multiple items")
@@ -379,6 +390,223 @@ class BasketControllerTest {
         verify(apiClientService).getItem("passthrough", "/path/to/item");
         verify(basketService).getBasketById("id");
         verify(itemMapper).itemToBasketItemDTO(certificateResource);
+    }
+
+    @Test
+    @DisplayName("Controller throws an error when request isn't valid")
+    void controllerErrorsWhenRequestJsonNotEmpty() {
+        // given
+        String requestJson = "nonemptytext";
+
+        // when
+        ResponseEntity<?> actual = controllerUnderTest.checkoutBasket(requestJson,
+                httpServletRequest, "123");
+
+        // then
+        assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode());
+        assertEquals(new ApiError(BAD_REQUEST, "The body must be empty"), actual.getBody());
+    }
+
+    @Test
+    @DisplayName("Basket throws a conflict exception if unable to locate id")
+    void conflictErrorThrownByBasketService() {
+        // given
+        when(basketService.getBasketById(any())).thenThrow(ConflictException.class);
+
+        // when
+        Executable executable = () -> controllerUnderTest.checkoutBasket(any(), httpServletRequest,
+                "123");
+
+        // then
+       assertThrows(ConflictException.class, executable);
+    }
+
+    @Test
+    @DisplayName("Conflict error if errors contains basket items missing error type")
+    void validatorErrorBasketItemMissing() {
+        // given
+        Basket basket = createBasket();
+        basket.getData().setItems(Arrays.asList(certificate, document, missingImage));
+
+        List<String> missingBasketErrors =
+                Arrays.asList(ErrorType.BASKET_ITEMS_MISSING.getValue());
+
+        when(basketService.getBasketById(any())).thenReturn(Optional.of(basket));
+        when(checkoutBasketValidator.getValidationErrors(any(), any())).thenReturn(missingBasketErrors);
+
+        // when
+        ResponseEntity<?> actual = controllerUnderTest.checkoutBasket(any(),
+                httpServletRequest, "123");
+
+        // then
+        assertEquals(HttpStatus.CONFLICT, actual.getStatusCode());
+        assertEquals(new ApiError(CONFLICT, "Basket is empty"), actual.getBody());
+    }
+
+    @Test
+    @DisplayName("Bad request error if errors contains basket item invalid error type")
+    void validatorErrorBasketItemInvalid() {
+        // given
+        Basket basket = createBasket();
+        basket.getData().setItems(Arrays.asList(certificate, document, missingImage));
+
+        List<String> invalidItemErrors =
+                Arrays.asList(ErrorType.BASKET_ITEM_INVALID.getValue());
+
+        when(basketService.getBasketById(any())).thenReturn(Optional.of(basket));
+        when(checkoutBasketValidator.getValidationErrors(any(), any())).thenReturn(invalidItemErrors);
+
+        // when
+        ResponseEntity<?> actual = controllerUnderTest.checkoutBasket(any(),
+                httpServletRequest, "123");
+
+        // then
+        assertEquals(BAD_REQUEST, actual.getStatusCode());
+        assertEquals(new ApiError(BAD_REQUEST, "Failed to retrieve item"), actual.getBody());
+    }
+
+    @Test
+    @DisplayName("Conflict error if errors contains missing delivery details error type")
+    void placeholder4() {
+        // given
+        Basket basket = createBasket();
+        basket.getData().setItems(Arrays.asList(certificate, document, missingImage));
+
+        List<String> deliveryDetailsErrors =
+                Arrays.asList(ErrorType.DELIVERY_DETAILS_MISSING.getValue());
+
+        when(basketService.getBasketById(any())).thenReturn(Optional.of(basket));
+        when(checkoutBasketValidator.getValidationErrors(any(), any())).thenReturn(deliveryDetailsErrors);
+
+        // when
+        ResponseEntity<?> actual = controllerUnderTest.checkoutBasket(any(),
+                httpServletRequest, "123");
+
+        // then
+        assertEquals(CONFLICT, actual.getStatusCode());
+        assertEquals(new ApiError(CONFLICT, "Delivery details missing for postal delivery"), actual.getBody());
+    }
+
+    @Test
+    @DisplayName("Bad request exception thrown when api client unable to retrieve item")
+    void apiClientThrowsBadRequest() throws IOException {
+        // given
+        Basket basket = createBasket();
+        basket.getData().setItems(Arrays.asList(certificate));
+        List<String> emptyErrorsList = Collections.EMPTY_LIST;
+
+        when(basketService.getBasketById(any())).thenReturn(Optional.of(basket));
+        when(checkoutBasketValidator.getValidationErrors(any(), any())).thenReturn(emptyErrorsList);
+        when(apiClientService.getItem(any(), any())).thenThrow(IOException.class);
+
+        // when
+        ResponseEntity<?> actual = controllerUnderTest.checkoutBasket(any(),
+                httpServletRequest, "123");
+
+        // then
+        assertEquals(BAD_REQUEST, actual.getStatusCode());
+        assertEquals(new ApiError(BAD_REQUEST, "Failed to retrieve item"), actual.getBody());
+    }
+
+    @Test
+    @DisplayName("Accepted status code when no errors or exceptions are thrown")
+    void controllerSuccessfullyCreatesCheckout() {
+        // given
+        Basket basket = createBasket();
+        basket.getData().setItems(Arrays.asList(certificate));
+        List<String> emptyErrorsList = Collections.EMPTY_LIST;
+
+        Checkout checkout = new Checkout();
+        CheckoutData checkoutData = new CheckoutData();
+        checkoutData.setTotalOrderCost("35");
+        checkout.setData(checkoutData);
+
+        when(basketService.getBasketById(any())).thenReturn(Optional.of(basket));
+        when(checkoutBasketValidator.getValidationErrors(any(), any())).thenReturn(emptyErrorsList);
+        when(checkoutService.createCheckout(any(), any(), any(), any())).thenReturn(checkout);
+
+        // when
+        ResponseEntity<?> actual = controllerUnderTest.checkoutBasket(any(),
+                httpServletRequest, "123");
+
+        // then
+        assertEquals(ACCEPTED, actual.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("OK status when no errors and total costs is 0")
+    void controllerCreatesCheckoutWhenTotalCostIsFree() {
+        // given
+        Basket basket = createBasket();
+        basket.getData().setItems(Arrays.asList(certificate));
+        List<String> emptyErrorsList = Collections.EMPTY_LIST;
+
+        Checkout checkout = new Checkout();
+        CheckoutData checkoutData = new CheckoutData();
+        checkoutData.setTotalOrderCost("0");
+        checkout.setData(checkoutData);
+
+        when(basketService.getBasketById(any())).thenReturn(Optional.of(basket));
+        when(checkoutBasketValidator.getValidationErrors(any(), any())).thenReturn(emptyErrorsList);
+        when(checkoutService.createCheckout(any(), any(), any(), any())).thenReturn(checkout);
+
+        // when
+        ResponseEntity<?> actual = controllerUnderTest.checkoutBasket(any(),
+                httpServletRequest, "123");
+
+        // then
+        assertEquals(OK, actual.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Accepted status code when checkout created for multiple items")
+    void createsCheckoutSuccessfullyForMultipleItems() {
+        // given
+        Basket basket = createBasket();
+        basket.getData().setItems(Arrays.asList(certificate, document));
+        List<String> emptyErrorsList = Collections.EMPTY_LIST;
+
+        Checkout checkout = new Checkout();
+        CheckoutData checkoutData = new CheckoutData();
+        checkoutData.setTotalOrderCost("35");
+        checkout.setData(checkoutData);
+
+        when(basketService.getBasketById(any())).thenReturn(Optional.of(basket));
+        when(checkoutBasketValidator.getValidationErrors(any(), any())).thenReturn(emptyErrorsList);
+        when(checkoutService.createCheckout(any(), any(), any(), any())).thenReturn(checkout);
+
+        // when
+        ResponseEntity<?> actual = controllerUnderTest.checkoutBasket(any(),
+                httpServletRequest, "123");
+
+        // then
+        assertEquals(ACCEPTED, actual.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Accepted status code when error occurs in one of many items")
+    void apiClientErrorForMultipleItems() throws IOException {
+        // given
+        Basket basket = createBasket();
+        basket.getData().setItems(Arrays.asList(certificate, document));
+        List<String> emptyErrorsList = Collections.EMPTY_LIST;
+
+        Checkout checkout = new Checkout();
+        CheckoutData checkoutData = new CheckoutData();
+        checkoutData.setTotalOrderCost("35");
+        checkout.setData(checkoutData);
+
+        when(basketService.getBasketById(any())).thenReturn(Optional.of(basket));
+        when(checkoutBasketValidator.getValidationErrors(any(), any())).thenReturn(emptyErrorsList);
+        when(checkoutService.createCheckout(any(), any(), any(), any())).thenReturn(checkout);
+        when(apiClientService.getItem(any(), any())).thenThrow(IOException.class);
+
+        // when
+        ResponseEntity<?> actual = controllerUnderTest.checkoutBasket(any(),
+                httpServletRequest, "123");
+
+        // then
+        assertEquals(ACCEPTED, actual.getStatusCode());
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
@@ -50,7 +50,6 @@ import uk.gov.companieshouse.orders.api.model.ApiError;
 import uk.gov.companieshouse.orders.api.model.Basket;
 import uk.gov.companieshouse.orders.api.model.BasketData;
 import uk.gov.companieshouse.orders.api.model.Certificate;
-import uk.gov.companieshouse.orders.api.model.CertifiedCopy;
 import uk.gov.companieshouse.orders.api.model.Checkout;
 import uk.gov.companieshouse.orders.api.model.CheckoutData;
 import uk.gov.companieshouse.orders.api.model.Item;

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
@@ -473,7 +473,7 @@ class BasketControllerTest {
 
     @Test
     @DisplayName("Conflict error if errors contains missing delivery details error type")
-    void placeholder4() {
+    void validatorErrorDeliveryDetailsMissing() {
         // given
         Basket basket = createBasket();
         basket.getData().setItems(Arrays.asList(certificate, document, missingImage));

--- a/src/test/java/uk/gov/companieshouse/orders/api/interceptor/OrdersApiAuthenticationTests.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/interceptor/OrdersApiAuthenticationTests.java
@@ -20,6 +20,7 @@ import static uk.gov.companieshouse.orders.api.util.TestConstants.REQUEST_ID_HEA
 import static uk.gov.companieshouse.orders.api.util.TestConstants.TOKEN_PERMISSION_VALUE;
 import static uk.gov.companieshouse.orders.api.util.TestConstants.TOKEN_REQUEST_ID_VALUE;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -193,7 +194,9 @@ class OrdersApiAuthenticationTests {
 
 		when(basketService.getBasketById(anyString())).thenReturn(Optional.of(basket));
 		when(checkoutService.createCheckout(
-				any(Certificate.class), any(String.class), any(String.class), any(DeliveryDetails.class)))
+				any(List.class), any(String.class),
+				any(String.class),
+				any(DeliveryDetails.class)))
 				.thenReturn(checkout);
 
 		CheckoutData checkoutDataResp = new CheckoutData();

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapperTest.java
@@ -49,7 +49,7 @@ class CheckoutToPaymentDetailsMapperTest {
     static final ActionedBy CHECKED_OUT_BY = new ActionedBy();
     static final String ITEM_ID = "CHS00000000000000001";
     static final String COMPANY_NAME = "Dummies Ltd";
-    static final String COMPANY_NUMBER = "00000000";
+    static final String COMPANY_NUMBER = "00000001";
     static final String DESC_VALUE_KEY = "company_number";
     static final String DESC_IDENTIFIER = "certificate";
     static final String DESCRIPTION = "certificate for company 00006400";

--- a/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/mapper/CheckoutToPaymentDetailsMapperTest.java
@@ -49,7 +49,7 @@ class CheckoutToPaymentDetailsMapperTest {
     static final ActionedBy CHECKED_OUT_BY = new ActionedBy();
     static final String ITEM_ID = "CHS00000000000000001";
     static final String COMPANY_NAME = "Dummies Ltd";
-    static final String COMPANY_NUMBER = "000000001";
+    static final String COMPANY_NUMBER = "00000000";
     static final String DESC_VALUE_KEY = "company_number";
     static final String DESC_IDENTIFIER = "certificate";
     static final String DESCRIPTION = "certificate for company 00006400";
@@ -110,7 +110,6 @@ class CheckoutToPaymentDetailsMapperTest {
         ITEM.setTotalItemCost(TOTAL_ITEM_COST);
         ITEM.setPostalDelivery(POSTAL_DELIVERY);
         ITEMS.add(ITEM);
-
         CHECKED_OUT_BY.setEmail(USER_EMAIL);
         CHECKED_OUT_BY.setId(USER_ID);
 
@@ -153,9 +152,7 @@ class CheckoutToPaymentDetailsMapperTest {
         assertThat(target.getKind(), is(EXPECTED_KIND));
         assertThat(target.getStatus(), is(source.getData().getStatus()));
         assertThat(target.getPaymentReference(), is(source.getData().getReference()));
-        assertThat(target.getCompanyNumber(), is(COMPANY_NUMBER));
         assertThat(target.getPaidAt(), is(PAID_AT_DATE));
-
         testLinks(source, target);
         testItems(source, target);
     }

--- a/src/test/java/uk/gov/companieshouse/orders/api/service/CheckoutServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/service/CheckoutServiceTest.java
@@ -126,7 +126,8 @@ public class CheckoutServiceTest {
 
         timestamps.start();
 
-        serviceUnderTest.createCheckout(new Certificate(), ERIC_IDENTITY_VALUE,
+        serviceUnderTest.createCheckout(Collections.singletonList(new Certificate()),
+                ERIC_IDENTITY_VALUE,
                 ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
         verify(checkoutRepository).save(checkoutCaptor.capture());
 
@@ -141,7 +142,7 @@ public class CheckoutServiceTest {
         certificate.setCompanyNumber(COMPANY_NUMBER);
         when(checkoutRepository.save(any(Checkout.class))).thenReturn(new Checkout());
 
-        serviceUnderTest.createCheckout(certificate, ERIC_IDENTITY_VALUE,
+        serviceUnderTest.createCheckout(Collections.singletonList(certificate), ERIC_IDENTITY_VALUE,
                 ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
         verify(checkoutRepository).save(checkoutCaptor.capture());
 
@@ -156,7 +157,8 @@ public class CheckoutServiceTest {
     void createCheckoutPopulatesAndSavesCheckedOutBy() {
         when(checkoutRepository.save(any(Checkout.class))).thenReturn(new Checkout());
 
-        serviceUnderTest.createCheckout(new Certificate(), ERIC_IDENTITY_VALUE,
+        serviceUnderTest.createCheckout(Collections.singletonList(new Certificate()),
+                ERIC_IDENTITY_VALUE,
                 ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
         verify(checkoutRepository).save(checkoutCaptor.capture());
 
@@ -178,7 +180,8 @@ public class CheckoutServiceTest {
         deliveryDetails.setRegion(REGION);
         deliveryDetails.setSurname(SURNAME);
 
-        serviceUnderTest.createCheckout(new Certificate(), ERIC_IDENTITY_VALUE,
+        serviceUnderTest.createCheckout(Collections.singletonList(new Certificate()),
+                ERIC_IDENTITY_VALUE,
                 ERIC_AUTHORISED_USER_VALUE, deliveryDetails);
         verify(checkoutRepository).save(checkoutCaptor.capture());
 
@@ -204,7 +207,8 @@ public class CheckoutServiceTest {
         when(etagGeneratorService.generateEtag()).thenReturn(ETAG);
         when(linksGeneratorService.generateCheckoutLinks(any(String.class))).thenReturn(checkoutLinks);
 
-        serviceUnderTest.createCheckout(new Certificate(), ERIC_IDENTITY_VALUE,
+        serviceUnderTest.createCheckout(Collections.singletonList(new Certificate()),
+                ERIC_IDENTITY_VALUE,
                 ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
         verify(checkoutRepository).save(checkoutCaptor.capture());
 
@@ -220,7 +224,8 @@ public class CheckoutServiceTest {
     void createCheckoutPopulatesTotalOrderCost() {
         Item certificateItem = createCertificateItem();
         doCallRealMethod().when(checkoutHelper).calculateTotalOrderCostForCheckout(any());
-        serviceUnderTest.createCheckout(certificateItem, ERIC_IDENTITY_VALUE,
+        serviceUnderTest.createCheckout(Collections.singletonList(certificateItem),
+                ERIC_IDENTITY_VALUE,
                 ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
         verify(checkoutRepository).save(checkoutCaptor.capture());
 
@@ -231,7 +236,8 @@ public class CheckoutServiceTest {
     @DisplayName("createCheckout populates `id` in the format ORD-######-######")
     void createCheckoutPopulatesIdCorrectly() {
         Item certificateItem = createCertificateItem();
-        serviceUnderTest.createCheckout(certificateItem, ERIC_IDENTITY_VALUE,
+        serviceUnderTest.createCheckout(Collections.singletonList(certificateItem),
+                ERIC_IDENTITY_VALUE,
                 ERIC_AUTHORISED_USER_VALUE, new DeliveryDetails());
         verify(checkoutRepository).save(checkoutCaptor.capture());
         assertTrue(checkout().getId().matches("^ORD-\\d{6}-\\d{6}$")); ;

--- a/src/test/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidatorTest.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.orders.api.validator;
 
+import java.io.IOException;
+import java.util.Arrays;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -73,6 +75,23 @@ public class CheckoutBasketValidatorTest {
     }
 
     @Test
+    @DisplayName("getValidation does not error when multiple basket "
+            + "contains items with one item invalid")
+    public void multipleItemBasketInvalidItem () throws IOException {
+        // Given
+        Basket basket = setUpBasketWithOneInvalidItem();
+        when(apiClientService.getItem(PASS_THROUGH_HEADER,
+                INVALID_ITEM_URI)).thenThrow(IOException.class);
+
+        // When
+        List<String> errors = validatorUnderTest.getValidationErrors(PASS_THROUGH_HEADER, basket);
+
+        // Then
+        assertThat(errors.isEmpty(), is(true));
+        assertThat(errors.size(), is(0));
+    }
+
+    @Test
     @DisplayName("getValidationErrors returns error for missing delivery details for postal delivery")
     public void getValidationErrorsReportsMissingDeliveryDetails() throws Exception {
         // Given
@@ -127,6 +146,26 @@ public class CheckoutBasketValidatorTest {
         basketItem.setItemUri(INVALID_ITEM_URI);
         basketItem.setPostalDelivery(false);
         basketData.setItems(Collections.singletonList(basketItem));
+        basket.setData(basketData);
+
+        return basket;
+    }
+
+    private Basket setUpBasketWithOneInvalidItem() {
+        Basket basket = new Basket();
+        BasketData basketData = new BasketData();
+        Item basketItem = new Item();
+        basketItem.setItemUri(INVALID_ITEM_URI);
+        basketItem.setPostalDelivery(false);
+
+        Certificate certificate = new Certificate();
+        certificate.setCompanyNumber(COMPANY_NUMBER);
+        certificate.setItemCosts(ITEM_COSTS);
+        certificate.setPostageCost(POSTAGE_COST);
+        certificate.setTotalItemCost(TOTAL_ITEM_COST);
+        certificate.setPostalDelivery(true);
+
+        basketData.setItems(Arrays.asList(basketItem, certificate));
         basket.setData(basketData);
 
         return basket;

--- a/src/test/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/validator/CheckoutBasketValidatorTest.java
@@ -75,7 +75,7 @@ public class CheckoutBasketValidatorTest {
 
     @Test
     @DisplayName("getValidation does error when multiple items in basket and one fails validation")
-    public void multipleItemBasketInvalidItem () throws IOException {
+    void multipleItemBasketInvalidItem () throws IOException {
         // Given
         Basket basket = setUpBasketWithOneInvalidItem();
         Certificate certificate = new Certificate();


### PR DESCRIPTION
* Change BaskerController to support multiple item processing, used to calculate correct total costs
* Change CheckoutBasketValidator to allow multi items to be processed
* Change CheckoutToPaymentDetailsMapper for multi item support, used for getting payment details
* Remove the setCompanyNumber mapping in the above mapper
* **Tested journey locally with API changes, confirm that everything works as expected.**


Resolves [GCI-2209 Total should be calculated from all items in basket](https://companieshouse.atlassian.net/browse/GCI-2209) 