### PR TITLE
GCI-2265 implement new getOrderItem endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/OrderController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/OrderController.java
@@ -15,6 +15,7 @@ import uk.gov.companieshouse.orders.api.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.orders.api.logging.LoggingUtils;
 import uk.gov.companieshouse.orders.api.model.Checkout;
 import uk.gov.companieshouse.orders.api.model.CheckoutData;
+import uk.gov.companieshouse.orders.api.model.Item;
 import uk.gov.companieshouse.orders.api.model.Order;
 import uk.gov.companieshouse.orders.api.model.CheckoutCriteria;
 import uk.gov.companieshouse.orders.api.model.OrderData;
@@ -51,6 +52,8 @@ public class OrderController {
     public static final String GET_ORDER_URI =
             "${uk.gov.companieshouse.orders.api.orders}/{" + ORDER_ID_PATH_VARIABLE + "}";
 
+    public static final String GET_ORDER_ITEM_URI = "/orders/{orderId}/items/{itemId}";
+
     /** <code>${uk.gov.companieshouse.orders.api.checkouts}/{id}</code> */
     public static final String GET_CHECKOUT_URI =
         "${uk.gov.companieshouse.orders.api.checkouts}/{" + CHECKOUT_ID_PATH_VARIABLE + "}";
@@ -81,6 +84,21 @@ public class OrderController {
         logMap.put(LoggingUtils.STATUS, HttpStatus.OK);
         LOGGER.info("Order found and returned", logMap);
         return ResponseEntity.ok().body(orderRetrieved.getData());
+    }
+
+    @GetMapping(GET_ORDER_ITEM_URI)
+    public ResponseEntity<Item> getOrderItem(final @PathVariable("orderId") String orderId,
+                                             final @PathVariable("itemId") String itemId,
+                                             final @RequestHeader(REQUEST_ID_HEADER_NAME) String requestId) {
+        Map<String, Object> logMap = createLogMapWithRequestId(requestId);
+        logIfNotNull(logMap, LoggingUtils.ORDER_ID, orderId);
+        logIfNotNull(logMap, LoggingUtils.ITEM_ID, itemId);
+        LOGGER.info("Retrieving order item", logMap);
+        final Item item = orderService.getOrderItem(orderId, itemId)
+                                                 .orElseThrow(ResourceNotFoundException::new);
+        logMap.put(LoggingUtils.STATUS, HttpStatus.OK);
+        LOGGER.info("Order item found and returned", logMap);
+        return ResponseEntity.ok().body(item);
     }
 
     @GetMapping(GET_CHECKOUT_URI)

--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/OrderController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/OrderController.java
@@ -52,7 +52,7 @@ public class OrderController {
     public static final String GET_ORDER_URI =
             "${uk.gov.companieshouse.orders.api.orders}/{" + ORDER_ID_PATH_VARIABLE + "}";
 
-    public static final String GET_ORDER_ITEM_URI = "/orders/{orderId}/items/{itemId}";
+    public static final String GET_ORDER_ITEM_URI = "/orders/{id}/items/{itemId}";
 
     /** <code>${uk.gov.companieshouse.orders.api.checkouts}/{id}</code> */
     public static final String GET_CHECKOUT_URI =
@@ -87,7 +87,7 @@ public class OrderController {
     }
 
     @GetMapping(GET_ORDER_ITEM_URI)
-    public ResponseEntity<Item> getOrderItem(final @PathVariable("orderId") String orderId,
+    public ResponseEntity<Item> getOrderItem(final @PathVariable("id") String orderId,
                                              final @PathVariable("itemId") String itemId,
                                              final @RequestHeader(REQUEST_ID_HEADER_NAME) String requestId) {
         Map<String, Object> logMap = createLogMapWithRequestId(requestId);

--- a/src/main/java/uk/gov/companieshouse/orders/api/interceptor/RequestUris.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/interceptor/RequestUris.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.orders.api.interceptor;
 
 import static uk.gov.companieshouse.orders.api.controller.BasketController.*;
 import static uk.gov.companieshouse.orders.api.controller.OrderController.GET_CHECKOUT_URI;
+import static uk.gov.companieshouse.orders.api.controller.OrderController.GET_ORDER_ITEM_URI;
 import static uk.gov.companieshouse.orders.api.controller.OrderController.GET_ORDER_URI;
 import static uk.gov.companieshouse.orders.api.controller.OrderController.CHECKOUTS_SEARCH_URI;
 import static uk.gov.companieshouse.orders.api.controller.OrderController.POST_REPROCESS_ORDER_URI;
@@ -24,6 +25,7 @@ class RequestUris {
     static final String PATCH_BASKET = "basket";
     static final String PATCH_PAYMENT_DETAILS = "patchPaymentDetails";
     static final String GET_ORDER = "getOrder";
+    static final String GET_ORDER_ITEM = "getOrderItem";
     static final String SEARCH = "searchCheckouts";
     static final String GET_CHECKOUT = "getCheckout";
     static final String POST_REPROCESS_ORDER = "postReprocessOrder";
@@ -41,6 +43,8 @@ class RequestUris {
     private String getPaymentDetailsUri;
     @Value(GET_ORDER_URI)
     private String getOrderUri;
+    @Value(GET_ORDER_ITEM_URI)
+    private String getOrderItemUri;
     @Value(CHECKOUTS_SEARCH_URI)
     private String searchUri;
     @Value(GET_CHECKOUT_URI)
@@ -108,6 +112,12 @@ class RequestUris {
                 .paths(getOrderUri)
                 .methods(RequestMethod.GET)
                 .mappingName(GET_ORDER)
+                .build());
+
+        knownRequests.add(RequestMappingInfo
+                .paths(getOrderItemUri)
+                .methods(RequestMethod.GET)
+                .mappingName(GET_ORDER_ITEM)
                 .build());
 
         knownRequests.add(RequestMappingInfo

--- a/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthenticationInterceptor.java
@@ -56,6 +56,7 @@ public class UserAuthenticationInterceptor implements HandlerInterceptor {
                 return hasSignedInUser(request, response);
             case GET_PAYMENT_DETAILS:
             case GET_ORDER:
+            case GET_ORDER_ITEM:
                 return hasAuthenticatedClient(request, response);
             case GET_CHECKOUT:
             case SEARCH:

--- a/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthorisationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthorisationInterceptor.java
@@ -11,6 +11,7 @@ import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.CHECKOUT_
 import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.GET_BASKET_LINKS;
 import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.GET_CHECKOUT;
 import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.GET_ORDER;
+import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.GET_ORDER_ITEM;
 import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.GET_PAYMENT_DETAILS;
 import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.PATCH_PAYMENT_DETAILS;
 import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.POST_REPROCESS_ORDER;
@@ -86,6 +87,7 @@ public class UserAuthorisationInterceptor implements HandlerInterceptor {
             case GET_CHECKOUT:
                 return securityManager.checkPermission() || getRequestClientIsAuthorised(request, response, this::getCheckoutUserIsResourceOwner);
             case GET_ORDER:
+            case GET_ORDER_ITEM:
                 return getRequestClientIsAuthorised(request, response, this::getOrderUserIsResourceOwner);
             case SEARCH:
                 return securityManager.checkPermission();

--- a/src/main/java/uk/gov/companieshouse/orders/api/service/OrderService.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/service/OrderService.java
@@ -18,6 +18,7 @@ import uk.gov.companieshouse.orders.api.kafka.OrderReceivedMessageProducer;
 import uk.gov.companieshouse.orders.api.logging.LoggingUtils;
 import uk.gov.companieshouse.orders.api.mapper.CheckoutToOrderMapper;
 import uk.gov.companieshouse.orders.api.model.Checkout;
+import uk.gov.companieshouse.orders.api.model.Item;
 import uk.gov.companieshouse.orders.api.model.Order;
 import uk.gov.companieshouse.orders.api.repository.CheckoutRepository;
 import uk.gov.companieshouse.orders.api.repository.OrderRepository;
@@ -90,6 +91,16 @@ public class OrderService {
 
     public Optional<Order> getOrder(String id) {
         return orderRepository.findById(id);
+    }
+
+    public Optional<Item> getOrderItem(String orderId, String itemId) {
+        Optional<Order> order = getOrder(orderId);
+        return order.flatMap(o -> o.getData()
+                                   .getItems()
+                                   .stream()
+                                   .filter(item -> item.getId().equals(itemId))
+                                   .findFirst());
+
     }
 
     public Optional<Checkout> getCheckout(String id) {

--- a/src/test/java/uk/gov/companieshouse/orders/api/interceptor/RequestMapperTests.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/interceptor/RequestMapperTests.java
@@ -15,6 +15,7 @@ import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.BASKET;
 import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.CHECKOUT_BASKET;
 import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.GET_CHECKOUT;
 import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.GET_ORDER;
+import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.GET_ORDER_ITEM;
 import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.GET_PAYMENT_DETAILS;
 import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.PATCH_PAYMENT_DETAILS;
 import static uk.gov.companieshouse.orders.api.interceptor.RequestUris.SEARCH;
@@ -121,6 +122,17 @@ class RequestMapperTests {
 
         // When and then
         assertThat(requestMapperUnderTest.getRequestMapping(request).getName(), is(GET_ORDER));
+    }
+
+    @Test
+    @DisplayName("getRequestMappingInfo gets the get order item request mapping")
+    void getRequestMappingInfoGetsGetOrderItem() {
+
+        // Given
+        givenRequest(GET, "/orders/{orderId}/items/{itemId}");
+
+        // When and then
+        assertThat(requestMapperUnderTest.getRequestMapping(request).getName(), is(GET_ORDER_ITEM));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthenticationInterceptorTests.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/interceptor/UserAuthenticationInterceptorTests.java
@@ -402,6 +402,7 @@ class UserAuthenticationInterceptorTests {
     private static Stream<Arguments> authenticatedRequestFixtures() {
         return Stream.of(arguments("preHandle accepts get checkout request that has authenticated API headers", "/checkouts/1234"),
                 arguments("preHandle accepts get order request that has authenticated API headers", "/orders/1234"),
+                arguments("preHandle accepts get order item request that has authenticated API headers", "/orders/1234/items/5678"),
                 arguments("preHandle accepts get payment details request that has authenticated API headers", "/basket/checkouts/1234/payment"));
     }
 
@@ -409,6 +410,7 @@ class UserAuthenticationInterceptorTests {
         return Stream.of(arguments("preHandle rejects get payment details request that lacks required headers", "/basket/checkouts/1234/payment"),
                 arguments("preHandle rejects get basket request that lacks required headers", "/basket"),
                 arguments("preHandle rejects get order request that lacks required headers", "/orders/1234"),
+                arguments("preHandle rejects get order item request that lacks required headers", "/orders/1234/items/5678"),
                 arguments("preHandle rejects get basket links request that lacks requires headers", "/basket/links"));
     }
 
@@ -423,6 +425,7 @@ class UserAuthenticationInterceptorTests {
     private static Stream<Arguments> signedInGetRequestFixtures() {
         return Stream.of(arguments("preHandle accepts get payment details request that has signed in user headers", "/basket/checkouts/1234/payment"),
                 arguments("preHandle accepts get order request that has signed in user headers", "/orders/1234"),
+                arguments("preHandle accepts get order item request that has signed in user headers", "/orders/1234/items/5678"),
                 arguments("preHandle accepts get basket links request from a user with OAuth2 authentication", "/basket/links"));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/orders/api/util/StubHelper.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/util/StubHelper.java
@@ -4,9 +4,11 @@ import static uk.gov.companieshouse.orders.api.util.TestConstants.ERIC_IDENTITY_
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
+import java.util.List;
 import uk.gov.companieshouse.orders.api.model.*;
 
 public final class StubHelper {
@@ -49,7 +51,8 @@ public final class StubHelper {
         return getCheckout(checkoutId, email, companyNumber, LocalDate.of(2022, 4, 12).atStartOfDay(), paymentStatus);
     }
 
-    public static Order getOrder(String orderId, String email, String companyNumber, LocalDateTime creationDate) {
+    public static Order getOrder(String orderId, List<Item> items, String email,
+            LocalDateTime creationDate) {
         final Order order = new Order();
         order.setId(orderId);
         order.setUserId(ERIC_IDENTITY_VALUE);
@@ -61,10 +64,7 @@ public final class StubHelper {
         orderData.setTotalOrderCost("100");
         orderData.setOrderedBy(new ActionedBy());
         orderData.getOrderedBy().setEmail(email);
-        orderData.setItems(Collections.singletonList(new Item()));
-        orderData.getItems().get(0).setId("item-id-123");
-        orderData.getItems().get(0).setKind("item#certificate");
-        orderData.getItems().get(0).setCompanyNumber(companyNumber);
+        orderData.setItems(items);
         orderData.setLinks(new OrderLinks());
         orderData.getLinks().setSelf("http");
 
@@ -73,8 +73,23 @@ public final class StubHelper {
         return order;
     }
 
+    public static Order getOrder(String orderId, String email, String companyNumber, LocalDateTime creationDate) {
+        return getOrder(orderId, Collections.singletonList(
+                getOrderItem("item-id-123", "item#certificate", companyNumber)),
+                email,
+                creationDate);
+    }
+
     public static Order getOrder(String orderId, String email, String companyNumber) {
         return getOrder(orderId, email, companyNumber, LocalDate.of(2022, 4, 12).atStartOfDay());
+    }
+
+    public static Item getOrderItem(String id, String kind, String companyNumber) {
+        Item orderItem = new Item();
+        orderItem.setId(id);
+        orderItem.setKind(kind);
+        orderItem.setCompanyNumber(companyNumber);
+        return orderItem;
     }
 
     public static Basket getBasket(String id) {


### PR DESCRIPTION
* Implement new getOrderItem controller endpoint and related service
  method.
* Endpoint searches existing order for matching item by ID. If no
  matching item found then HTTP 404 Not Found returned.

Resolves:
[GCI-2265](https://companieshouse.atlassian.net/browse/GCI-2265)