### PR TITLE
fix: update listener rule and remove log_level

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -1,4 +1,4 @@
-# Define all hardcoded local variable and local variables looked up from data resources
+ # Define all hardcoded local variable and local variables looked up from data resources
 locals {
   stack_name                  = "order-service" # this must match the stack name the service deploys into
   name_prefix                 = "${local.stack_name}-${var.environment}"
@@ -9,7 +9,7 @@ locals {
   docker_repo                 = "orders.api.ch.gov.uk"
   kms_alias                   = "alias/${var.aws_profile}/environment-services-kms"
   lb_listener_rule_priority   = 95
-  lb_listener_paths           = ["/orders-api/*","/orders/*","/checkouts/*","/basket/*" ]
+  lb_listener_paths           = ["/orders-api/*","/orders/*","/checkouts/*","/basket*" ]
   healthcheck_path            = "/orders-api/healthcheck" #healthcheck path for order-api
   healthcheck_matcher         = "200"
   vpc_name                    = local.stack_secrets["vpc_name"]
@@ -64,8 +64,7 @@ locals {
   task_secrets = concat(local.service_secret_list,local.global_secret_list,[])
 
   task_environment = concat(local.ssm_global_version_map,local.ssm_service_version_map,[
-    { "name" : "PORT", "value" : local.container_port },
-    { "name" : "LOGLEVEL", "value" : var.log_level }
+    { "name" : "PORT", "value" : local.container_port }
   ])
 
   # get eric secrets from global secrets map

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -3,4 +3,3 @@ aws_profile = "development-eu-west-2"
 
 # service configs
 use_set_environment_files = true
-log_level = "trace"

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -3,4 +3,3 @@ aws_profile = "live-eu-west-2"
 
 # service configs
 use_set_environment_files = true
-log_level = "info"

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -3,7 +3,6 @@ aws_profile = "staging-eu-west-2"
 
 # service configs
 use_set_environment_files = true
-log_level = "debug"
 
 # Scheduled scaling of tasks
 service_autoscale_enabled  = true

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -126,11 +126,7 @@ variable "use_set_environment_files" {
   default     = true
   description = "Toggle default global and shared  environment files"
 }
-variable "log_level" {
-  default     = "info"
-  type        = string
-  description = "The log level for services to use: trace, debug, info or error"
-}
+
 variable "orders_api_version" {
   type        = string
   description = "The version of the orders.api.ch.gov.uk container to run."


### PR DESCRIPTION
https://companieshouse.slack.com/archives/CMFDF43KM/p1717592689650029

Some endpoints for orders end in just /basket , so we need to modify the listener rules to account for this