### PR TITLE
BI-13910: Update system default time zone

### DIFF
--- a/src/main/java/uk/gov/companieshouse/orders/api/OrdersApiApplication.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/OrdersApiApplication.java
@@ -9,6 +9,9 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.orders.api.environment.RequiredEnvironmentVariables;
 import uk.gov.companieshouse.orders.api.logging.LoggingUtils;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class OrdersApiApplication {
     private static Logger LOGGER = LoggingUtils.getLogger();
@@ -17,6 +20,8 @@ public class OrdersApiApplication {
 
     public static void main(String[] args) {
         if(checkEnvironmentVariables()) {
+            TimeZone.setDefault(TimeZone.getTimeZone("Europe/London"));
+            Locale.setDefault(Locale.UK);
             SpringApplication.run(OrdersApiApplication.class, args);
         }
     }


### PR DESCRIPTION
This updates the system timezone to London to resolve datetime issues during BST (UTC+1) being reported incorrectly.