### PR TITLE
BI-13910: Fix paid_at datetime conversion

### DIFF
--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -11,6 +11,8 @@ import static uk.gov.companieshouse.orders.api.OrdersApiApplication.REQUEST_ID_H
 import static uk.gov.companieshouse.orders.api.logging.LoggingUtils.APPLICATION_NAME_SPACE;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -566,7 +568,7 @@ public class BasketController {
         final CheckoutData data = checkout.getData();
         data.setStatus(update.getStatus());
         if (update.getStatus() == PaymentStatus.PAID) {
-            data.setPaidAt(update.getPaidAt());
+            data.setPaidAt(update.getPaidAt().atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime());
             data.setPaymentReference(update.getPaymentReference());
         }
         checkoutService.saveCheckout(checkout);

--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -11,7 +11,6 @@ import static uk.gov.companieshouse.orders.api.OrdersApiApplication.REQUEST_ID_H
 import static uk.gov.companieshouse.orders.api.logging.LoggingUtils.APPLICATION_NAME_SPACE;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/uk/gov/companieshouse/orders/api/dto/BasketPaymentRequestDTO.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/dto/BasketPaymentRequestDTO.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.Gson;
 import uk.gov.companieshouse.orders.api.model.PaymentStatus;
 
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 
 public class BasketPaymentRequestDTO {

--- a/src/main/java/uk/gov/companieshouse/orders/api/dto/BasketPaymentRequestDTO.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/dto/BasketPaymentRequestDTO.java
@@ -5,11 +5,12 @@ import com.google.gson.Gson;
 import uk.gov.companieshouse.orders.api.model.PaymentStatus;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 public class BasketPaymentRequestDTO {
 
     @JsonProperty("paid_at")
-    private LocalDateTime paidAt;
+    private OffsetDateTime paidAt;
 
     @JsonProperty("payment_reference")
     private String paymentReference;
@@ -17,11 +18,11 @@ public class BasketPaymentRequestDTO {
     @JsonProperty("status")
     private PaymentStatus status;
 
-    public LocalDateTime getPaidAt() {
+    public OffsetDateTime getPaidAt() {
         return paidAt;
     }
 
-    public void setPaidAt(LocalDateTime paidAt) {
+    public void setPaidAt(OffsetDateTime paidAt) {
         this.paidAt = paidAt;
     }
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerIntegrationTest.java
@@ -57,6 +57,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2246,7 +2247,7 @@ class BasketControllerIntegrationTest extends AbstractMongoConfig {
 
     private BasketPaymentRequestDTO createBasketPaymentRequest(PaymentStatus paymentStatus) {
         final BasketPaymentRequestDTO basketPaymentRequestDTO = new BasketPaymentRequestDTO();
-        basketPaymentRequestDTO.setPaidAt(LocalDateTime.now());
+        basketPaymentRequestDTO.setPaidAt(OffsetDateTime.now());
         basketPaymentRequestDTO.setPaymentReference(PAYMENT_ID);
         basketPaymentRequestDTO.setStatus(paymentStatus);
 

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
@@ -20,7 +20,9 @@ import static uk.gov.companieshouse.orders.api.util.TestConstants.REQUEST_ID_HEA
 
 import java.io.IOException;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,6 +37,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cglib.core.Local;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -673,7 +676,8 @@ class BasketControllerTest {
         final String checkout_id = "123456789";
         final String payment_id = "987654321";
         final String eric_header = "EricHeader";
-        final LocalDateTime paidAt = LocalDateTime.now();
+        final OffsetDateTime paidAt = OffsetDateTime.now();
+        final LocalDateTime paidAtLocal = paidAt.toLocalDateTime();
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader(ApiSdkManager.getEricPassthroughTokenHeader(), eric_header);
@@ -704,7 +708,7 @@ class BasketControllerTest {
         // Then
         verify(checkoutData).setStatus(paymentOutcome);
         if (paymentOutcome.equals(PaymentStatus.PAID)) {
-            verify(checkoutData).setPaidAt(paidAt);
+            verify(checkoutData).setPaidAt(paidAtLocal);
             verify(checkoutData).setPaymentReference(payment_id);
         }
         verify(checkoutService).saveCheckout(checkout);

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
@@ -20,7 +20,6 @@ import static uk.gov.companieshouse.orders.api.util.TestConstants.REQUEST_ID_HEA
 
 import java.io.IOException;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -37,7 +36,6 @@ import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.cglib.core.Local;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;


### PR DESCRIPTION
This ensures that the `paid_at` value in the patch request that updates the `checkout` resource with the payment status saves the datetime correctly to Mongo using the correct UTC date time. Due to the timezone of the application now being set to `Europe/London` a LocalDateTime was having it saved an hour before due to no timezone data in a LocalDateTime object. 