### PR TITLE
Set static payment reference for free admin orders

### DIFF
--- a/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
+++ b/src/main/java/uk/gov/companieshouse/orders/api/controller/BasketController.java
@@ -422,10 +422,11 @@ public class BasketController {
         } else {
             logMap.put(LoggingUtils.STATUS, OK);
             LOGGER.infoRequest(request, "Basket checkout completed no payment required", logMap);
+            checkoutData.setPaymentReference("FREEINTERNALORDER");
+
             checkoutData.setStatus(PaymentStatus.FREE);
             processOrder(checkout, logMap);
             LOGGER.infoRequest(request, "Free order processed", logMap);
-
             return new ResponseEntity<>(checkoutData, OK);
         }
     }

--- a/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/orders/api/controller/BasketControllerTest.java
@@ -632,7 +632,6 @@ class BasketControllerTest {
                 httpServletRequest, "123");
 
         verify(checkoutData).setPaymentReference("FREEINTERNALORDER");
-        
         // then
         assertEquals(OK, actual.getStatusCode());
         assertEquals("FREEINTERNALORDER", checkout.getData().getPaymentReference());
@@ -658,7 +657,8 @@ class BasketControllerTest {
         // when
         ResponseEntity<?> actual = controllerUnderTest.checkoutBasket(any(),
                 httpServletRequest, "123");
-
+        
+        // then
         assertEquals(ACCEPTED, actual.getStatusCode());
     }
 


### PR DESCRIPTION
Resolves [BI-13973](https://companieshouse.atlassian.net/browse/BI-13973) 

Add dummy reference for free admin orders so that payment reference field can sucessfully reach ORDER-DETAILS and ORDER-HEADER table when passing through chd-order-api and chd-order-consumer.

[BI-13973]: https://companieshouse.atlassian.net/browse/BI-13973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ